### PR TITLE
Baseline devices

### DIFF
--- a/profile_bluesky/startup/instrument/devices/flat_mirror.py
+++ b/profile_bluesky/startup/instrument/devices/flat_mirror.py
@@ -17,16 +17,16 @@ class FlatMirror(Device):
 
     y_upstream   = Component(EpicsMotor,'m39',labels=('motor','mirrors'))
     y_downstream = Component(EpicsMotor,'m40',labels=('motor','mirrors'))
-    y = Component(EpicsSignal,'M2t2.D',write_pv=':M2avg',
+    y = Component(EpicsSignal,'M2t2.D',write_pv='M2avg',
                           labels=('mirrors'))
-    angle = Component(EpicsSignal,'M2t2.C',write_pv=':M2angl',
+    angle = Component(EpicsSignal,'M2t2.C',write_pv='M2angl',
                         labels=('mirrors'))
 
     x_upstream   = Component(EpicsMotor,'m37',labels=('motor','mirrors'))
     x_downstream = Component(EpicsMotor,'m38',labels=('motor','mirrors'))
-    x = Component(EpicsSignal,'M2xt2.D',write_pv=':M1xavg',
+    x = Component(EpicsSignal,'M2xt2.D',write_pv='M1xavg',
                           labels=('mirrors'))
-    x_angle = Component(EpicsSignal,'M1xt2.C',write_pv=':M1xangl',
+    x_angle = Component(EpicsSignal,'M1xt2.C',write_pv='M1xangl',
                         labels=('mirrors'))
 
 flat_mirror = FlatMirror('4idb:',name='flat mirror')

--- a/profile_bluesky/startup/instrument/devices/flat_mirror.py
+++ b/profile_bluesky/startup/instrument/devices/flat_mirror.py
@@ -11,6 +11,7 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from ophyd import Component, Device, EpicsMotor, EpicsSignal
+from ..framework import sd
 
 class FlatMirror(Device):
 
@@ -29,7 +30,7 @@ class FlatMirror(Device):
                         labels=('mirrors'))
 
 flat_mirror = FlatMirror('4idb:',name='flat mirror')
-
+sd.baseline.append(flat_mirror)
 # TODO: How to add the different default positions in the mirrors?
 # TODO: Check that the limits option of EpicsSignal will work!
 # TODO: KB mirrors.

--- a/profile_bluesky/startup/instrument/devices/huber.py
+++ b/profile_bluesky/startup/instrument/devices/huber.py
@@ -12,6 +12,7 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from ophyd import Component,EpicsMotor,MotorBundle
+from ..framework import sd
 
 ## Cryo carrier ##
 class CryoStage(MotorBundle):
@@ -20,6 +21,7 @@ class CryoStage(MotorBundle):
     z = Component(EpicsMotor, 'm16', labels=('motor', 'cryo'))  # Cryo Z
 
 cryo = CryoStage(prefix='4iddx:',name='cryo')
+sd.baseline.append(cryo)
 
 ## 8c rotations ##
 class Diffractometer(MotorBundle):
@@ -36,7 +38,7 @@ class Diffractometer(MotorBundle):
     y = Component(EpicsMotor,'m17', labels=('motor','diffractometer'))  # 8C verical
 
 huber = Diffractometer(prefix='4iddx:',name='huber')
-
+sd.baseline.append(huber)
 # TODO: look at todo folder. Use hklpy when setting these up, so that we
 #       can create fourc and sixc
 

--- a/profile_bluesky/startup/instrument/devices/kbic.py
+++ b/profile_bluesky/startup/instrument/devices/kbic.py
@@ -10,11 +10,13 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from ophyd import Component, MotorBundle, EpicsMotor
+from ..framework import sd
 
 class KBIC(MotorBundle):
     y = Component(EpicsMotor, 'm34', labels=('motor','kbic'))  # KB IC Y
     x = Component(EpicsMotor, 'm33', labels=('motor','kbic'))  # KB IC X
 
 kbic = KBIC('4iddx:',name='KBIC')
+sd.baseline.append(kbic)
 
 # TODO: Maybe other things that can be here? Like the motors for flags?

--- a/profile_bluesky/startup/instrument/devices/lakeshore336.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore336.py
@@ -39,7 +39,7 @@ class LS336_LoopControl(PVPositioner):
     manual = FormattedComponent(EpicsSignalWithRBV, "{self.prefix}OUT{self.loop_number}:MOUT", kind=Kind.config)
     mode = FormattedComponent(EpicsSignalWithRBV, "{self.prefix}OUT{self.loop_number}:Mode", kind=Kind.config)
     heater_range = FormattedComponent(EpicsSignalWithRBV, "{self.prefix}HTR{self.loop_number}:Range",
-                                      kind=Kind.config, auto_monitor=True)
+                                      kind=Kind.normal, auto_monitor=True)
 
     def __init__(self, *args,loop_number=None,timeout=60*60*10,**kwargs):
         self.loop_number = loop_number

--- a/profile_bluesky/startup/instrument/devices/lakeshore340.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore340.py
@@ -124,7 +124,7 @@ class LS340Device(Device):
 
     heater = Component(EpicsSignalRO, "Heater")
     heater_range = Component(EpicsSignal, "HeatRg",write_pv="Rg_rdbk",
-                             kind=Kind.omitted)
+                             kind=Kind.normal)
 
 
     read_pid = Component(EpicsSignal, "readPID.PROC", kind=Kind.omitted)

--- a/profile_bluesky/startup/instrument/devices/lakeshores.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshores.py
@@ -9,6 +9,7 @@ logger.info(__file__)
 
 from .lakeshore336 import LS336Device
 from .lakeshore340 import LS340Device
+from ..framework import sd
 
 lakeshore_336 = LS336Device("4idd:LS336:TC3:", name="lakeshore 360", labels=["Lakeshore"])
 
@@ -17,6 +18,10 @@ lakeshore_340lt = LS340Device('4idd:LS340:TC1:',name="lakeshore 340 - low temper
 
 lakeshore_340ht = LS340Device('4idd:LS340:TC2:',name="lakeshore 340 - high temperature",
                               labels=("Lakeshore"))
+
+sd.baseline.append(lakeshore_336)
+sd.baseline.append(lakeshore_340ht)
+sd.baseline.append(lakeshore_340lt)
 
 # TODO: include limits, Fix offset AttributeError
 # TODO: lakeshore 340 won't show a status bar, I don't know why.

--- a/profile_bluesky/startup/instrument/devices/magnets.py
+++ b/profile_bluesky/startup/instrument/devices/magnets.py
@@ -9,7 +9,8 @@ __all__ = [
 from ..session_logs import logger
 logger.info(__file__)
 
-from ophyd import Component, Device, EpicsMotor, FormattedComponent
+from ophyd import Component, Device, EpicsMotor
+from ..framework import sd
 
 ## Magnet and sample motors ##
 class Magnet6T(Device):
@@ -31,6 +32,7 @@ class Magnet6T(Device):
 
 
 mag6t = Magnet6T('4iddx:',name='6T_magnet')
+sd.baseline.append(mag6t)
 # Tvaporizer = lakeshore_336.loop1
 # Tsample = lakeshore_336.loop2
 

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -10,27 +10,22 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from apstools.devices import KohzuSeqCtl_Monochromator
-from ophyd import Component, EpicsSignalRO, EpicsMotor,Kind
+from ophyd import Component, EpicsSignalRO, EpicsMotor
 from ..framework import sd
 
 class Monochromator(KohzuSeqCtl_Monochromator):
 
     y1 = None
 
-    x2 = Component(EpicsMotor,'m6',labels=('motor','monochromator'),
-                  kind=Kind.omitted)
-    y2 = Component(EpicsSignalRO,'KohzuYRdbkAI',labels=('motor','monochromator'),
-                  kind=Kind.omitted)   # Kohzu Y2
-    z2 = Component(EpicsSignalRO,'KohzuZRdbkAI',labels=('motor','monochromator'),
-                  kind=Kind.omitted)  # Kohzu Z2
+    x2 = Component(EpicsMotor,'m6',labels=('motor','monochromator'))
+    y2 = Component(EpicsSignalRO,'KohzuYRdbkAI',labels=('motor','monochromator'))   # Kohzu Y2
+    z2 = Component(EpicsSignalRO,'KohzuZRdbkAI',labels=('motor','monochromator'))  # Kohzu Z2
 
     thf2 = Component(EpicsMotor,'m4',labels=('motor','monochromator'))  # Kohzu Th2f
     chi2 = Component(EpicsMotor,'m5', labels=('motor','monochromator'))  # Kohzu Chi
 
-    table_x = Component(EpicsMotor,'m7',labels=('motor','monochromator'),
-                  kind=Kind.omitted)
-    table_y = Component(EpicsMotor,'m8',labels=('motor','monochromator'),
-                  kind=Kind.omitted)
+    table_x = Component(EpicsMotor,'m7',labels=('motor','monochromator'))
+    table_y = Component(EpicsMotor,'m8',labels=('motor','monochromator'))
 
 
 mono = Monochromator('4idb:', name='monochromator')

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -11,26 +11,28 @@ logger.info(__file__)
 
 from apstools.devices import KohzuSeqCtl_Monochromator
 from ophyd import Component, EpicsSignalRO, EpicsMotor,Kind
+from ..framework import sd
 
 class Monochromator(KohzuSeqCtl_Monochromator):
-    
+
     y1 = None
-    
+
     x2 = Component(EpicsMotor,'m6',labels=('motor','monochromator'),
                   kind=Kind.omitted)
     y2 = Component(EpicsSignalRO,'KohzuYRdbkAI',labels=('motor','monochromator'),
                   kind=Kind.omitted)   # Kohzu Y2
     z2 = Component(EpicsSignalRO,'KohzuZRdbkAI',labels=('motor','monochromator'),
                   kind=Kind.omitted)  # Kohzu Z2
-    
+
     thf2 = Component(EpicsMotor,'m4',labels=('motor','monochromator'))  # Kohzu Th2f
     chi2 = Component(EpicsMotor,'m5', labels=('motor','monochromator'))  # Kohzu Chi
-    
+
     table_x = Component(EpicsMotor,'m7',labels=('motor','monochromator'),
                   kind=Kind.omitted)
     table_y = Component(EpicsMotor,'m8',labels=('motor','monochromator'),
                   kind=Kind.omitted)
-    
+
 
 mono = Monochromator('4idb:', name='monochromator')
 mono.stage_sigs['mode'] = 1 #Ensure that mono is in auto before moving.
+sd.baseline.append(mono)

--- a/profile_bluesky/startup/instrument/devices/phaseplates.py
+++ b/profile_bluesky/startup/instrument/devices/phaseplates.py
@@ -10,6 +10,7 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from ophyd import Device, EpicsMotor, FormattedComponent
+from ..framework import sd
 
 class PRDevice(Device):
 
@@ -30,4 +31,7 @@ pr1 = PRDevice('4idb','pr1',{'x':'m10','y':'m11','th':'m13'})
 pr2 = PRDevice('4idb','pr2',{'x':'m15','y':'m16','th':'m18'})
 pr3 = PRDevice('4idb','pr3',{'x':'m19','y':'m20','th':'m21'})
 
+sd.baseline.append(pr1)
+sd.baseline.append(pr2)
+sd.baseline.append(pr3)
 # TODO: add other stuff to pr's, like lock-in PVS, and screen position.

--- a/profile_bluesky/startup/instrument/devices/scaler.py
+++ b/profile_bluesky/startup/instrument/devices/scaler.py
@@ -12,12 +12,15 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from ophyd.scaler import ScalerCH
+from ..framework import sd
 
 scalerd = ScalerCH('4id:scaler1', name='scalerd', labels=('detectors','counters'))
 scalerd.select_channels(None)
+sd.baseline.append(scalerd)
 
 scalerb = ScalerCH('4idb:scaler1', name='scalerb', labels=('detectors','counters'))
 scalerb.select_channels(None)
+sd.baseline.append(scalerb)
 
 # TODO: name the other channels, watch out for python keywords such as del!
 # TODO: How should we handle the scalers? What is scaler3?

--- a/profile_bluesky/startup/instrument/devices/scaler.py
+++ b/profile_bluesky/startup/instrument/devices/scaler.py
@@ -19,6 +19,7 @@ scalerd.select_channels(None)
 sd.baseline.append(scalerd)
 
 scalerb = ScalerCH('4idb:scaler1', name='scalerb', labels=('detectors','counters'))
+scalerb.channels.chan01.chname.set('Time_b')
 scalerb.select_channels(None)
 sd.baseline.append(scalerb)
 

--- a/profile_bluesky/startup/instrument/devices/slits.py
+++ b/profile_bluesky/startup/instrument/devices/slits.py
@@ -8,6 +8,7 @@ from instrument.session_logs import logger
 logger.info(__file__)
 
 from ophyd import Device, EpicsMotor, EpicsSignal, FormattedComponent
+from ..framework import sd
 
 class SlitDevice(Device):
 
@@ -64,30 +65,36 @@ class SlitDevice(Device):
 wbslt = SlitDevice('4idb','wbslt',
                    {'top': 'm25','bot':'m26','out':'m27','inb':'m28'},
                    slitnum=1)
+sd.baseline.append(wbslt)
 
 ## Entrance slit ##
 enslt = SlitDevice('4iddx','enslt',
                    {'top': 'm1','bot':'m2','out':'m3','inb':'m4'},
                    slitnum=1)
+sd.baseline.append(enslt)
 
 ## 8C incident slit ##
 inslt = SlitDevice('4iddx','inslt',
                    {'top': 'm5','bot':'m6','out':'m7','inb':'m11'},
                    slitnum=2)
+sd.baseline.append(inslt)
 
 ## 2th guard slit ##
 grdslt = SlitDevice('4iddx','grdslt',
                     {'top': 'm21','bot':'m22','out':'m23','inb':'m24'},
                     slitnum=3)
+sd.baseline.append(grdslt)
 
 ## 2th detector slit ##
 detslt = SlitDevice('4iddx','detslt',
                     {'top': 'm25','bot':'m26','out':'m27','inb':'m28'},
                     slitnum=4)
+sd.baseline.append(detslt)
 
 ## Magnet incident slit ##
 magslt = SlitDevice('4iddx','magslt',
                     {'top': 'm29','bot':'m30','out':'m31','inb':'m32'},
                     slitnum=5)
+sd.baseline.append(magslt)
 
 # TODO: Test limits on EpicsSignal.

--- a/profile_bluesky/startup/instrument/devices/toroidal_mirror.py
+++ b/profile_bluesky/startup/instrument/devices/toroidal_mirror.py
@@ -11,6 +11,7 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from ophyd import Component, Device, EpicsMotor, EpicsSignal
+from ..framework import sd
 
 ## Toroidal Mirror ##
 class ToroidalMirror(Device):
@@ -33,6 +34,7 @@ class ToroidalMirror(Device):
     bender = Component(EpicsMotor,'m32',labels=('motor','mirrors'))
 
 toroidal_mirror = ToroidalMirror('4idb:',name='toroidal mirror')
+sd.baseline.append(toroidal_mirror)
 
 # TODO: How to add the different default positions in the mirrors?
 # TODO: Check that the limits option of EpicsSignal will work!

--- a/profile_bluesky/startup/instrument/devices/toroidal_mirror.py
+++ b/profile_bluesky/startup/instrument/devices/toroidal_mirror.py
@@ -18,17 +18,17 @@ class ToroidalMirror(Device):
 
     y_upstream   = Component(EpicsMotor,'m35',labels=('motor','mirrors'))
     y_downstream = Component(EpicsMotor,'m36',labels=('motor','mirrors'))
-    y = Component(EpicsSignal,'M1t2.D',write_pv=':M1avg',
+    y = Component(EpicsSignal,'M1t2.D',write_pv='M1avg',
                           labels=('motor','mirrors'))
-    angle = Component(EpicsSignal,'M1t2.C',write_pv=':M1angl',
+    angle = Component(EpicsSignal,'M1t2.C',write_pv='M1angl',
                         labels=('motor','mirrors'))
 
 
     x_upstream   = Component(EpicsMotor,'m33',labels=('motor','mirrors'))
     x_downstream = Component(EpicsMotor,'m34',labels=('motor','mirrors'))
-    x = Component(EpicsSignal,'M1xt2.D',write_pv=':M1xavg',
+    x = Component(EpicsSignal,'M1xt2.D',write_pv='M1xavg',
                           labels=('mirrors'))
-    x_angle = Component(EpicsSignal,'M1xt2.C',write_pv=':M1xangl',
+    x_angle = Component(EpicsSignal,'M1xt2.C',write_pv='M1xangl',
                         labels=('mirrors'))
 
     bender = Component(EpicsMotor,'m32',labels=('motor','mirrors'))

--- a/profile_bluesky/startup/instrument/devices/uptable.py
+++ b/profile_bluesky/startup/instrument/devices/uptable.py
@@ -10,9 +10,11 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from ophyd import Component, MotorBundle, EpicsMotor
+from ..framework import sd
 
 class UpTable(MotorBundle):
     y = Component(EpicsMotor, 'm10', labels=('motor','uptable'))  # Uptable Y
     x = Component(EpicsMotor, 'm9', labels=('motor','uptable'))  # Uptable Y
 
 uptab = UpTable('4iddx:',name='uptable')
+sd.baseline.append(uptab)

--- a/profile_bluesky/startup/instrument/devices/xbpm.py
+++ b/profile_bluesky/startup/instrument/devices/xbpm.py
@@ -10,9 +10,11 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from ophyd import Component,EpicsMotor,MotorBundle
+from ..framework import sd
 
 class XBPM(MotorBundle):
     y = Component(EpicsMotor, 'm20', labels=('motor','XBPM'))  # XBPM ver
     x = Component(EpicsMotor, 'm19', labels=('motor','XBPM'))  # XBPM hor
 
 xbpm = XBPM('4iddx:',name='XBPM')
+sd.baseline.append(xbpm)


### PR DESCRIPTION
- Added all devices to the _baseline_. In the future, we may want to be more selective about what goes into the baseline depending on the type of experiment.
- Tweaked the _kind_ of some components because if `kind=Kind.config`, then that component won't be saved to the _baseline_.
- Added a line to the _scalers.py_ to change the name of the _Time_ channel of scalerb to _Time_b_, because It cannot be the same as the one in scalerd.

fixes #21 