### PR TITLE
update for 2021_1 conda environment

### DIFF
--- a/profile_bluesky/startup/instrument/framework/initialize.py
+++ b/profile_bluesky/startup/instrument/framework/initialize.py
@@ -96,7 +96,7 @@ try:
         write_timeout=60,
         connection_timeout=5,
     )
-except Exception as exc:
+except Exception:
     warnings.warn(
         "ophyd version is old, upgrade to 1.6.0+ "
         "to get set_defaults() method"

--- a/profile_bluesky/startup/instrument/framework/initialize.py
+++ b/profile_bluesky/startup/instrument/framework/initialize.py
@@ -16,8 +16,26 @@ from ..session_logs import logger
 logger.info(__file__)
 
 from bluesky import RunEngine
+from bluesky import SupplementalData
+from bluesky.callbacks.best_effort import BestEffortCallback
+from bluesky.callbacks.broker import verify_files_saved
+from bluesky.magics import BlueskyMagics
+from bluesky.simulators import summarize_plan
 from bluesky.utils import PersistentDict
+from bluesky.utils import ProgressBarManager
+from bluesky.utils import ts_msg_hook
+from IPython import get_ipython
+from ophyd.signal import EpicsSignalBase
+import databroker
 import os
+
+
+# convenience imports
+import bluesky.plans as bp
+import bluesky.plan_stubs as bps
+import bluesky.preprocessors as bpp
+import numpy as np
+
 
 # Set up a RunEngine and use metadata-backed PersistentDict
 RE = RunEngine({})
@@ -29,7 +47,6 @@ RE.md = PersistentDict(
 callback_db = {}
 
 # Set up a Broker.
-import databroker
 db = databroker.Broker.named('mongodb_config')
 
 # Subscribe metadatastore to documents.
@@ -37,22 +54,17 @@ db = databroker.Broker.named('mongodb_config')
 callback_db['db'] = RE.subscribe(db.insert)
 
 # Set up SupplementalData.
-from bluesky import SupplementalData
 sd = SupplementalData()
 RE.preprocessors.append(sd)
 
 # Add a progress bar.
-from bluesky.utils import ProgressBarManager
 pbar_manager = ProgressBarManager()
 RE.waiting_hook = pbar_manager
 
 # Register bluesky IPython magics.
-from IPython import get_ipython
-from bluesky.magics import BlueskyMagics
 get_ipython().register_magics(BlueskyMagics)
 
 # Set up the BestEffortCallback.
-from bluesky.callbacks.best_effort import BestEffortCallback
 bec = BestEffortCallback()
 callback_db['bec'] = RE.subscribe(bec)
 peaks = bec.peaks  # just an alias, for less typing
@@ -60,27 +72,14 @@ bec.disable_baseline()
 
 # At the end of every run, verify that files were saved and
 # print a confirmation message.
-from bluesky.callbacks.broker import verify_files_saved
 # callback_db['post_run_verify'] = RE.subscribe(post_run(verify_files_saved), 'stop')
-
-# convenience imports
-# from bluesky.callbacks import *
-# from bluesky.callbacks.broker import *
-# from bluesky.simulators import *
-import bluesky.plans as bp
-import bluesky.plan_stubs as bps
-import bluesky.preprocessors as bpp
-import numpy as np
 
 # Uncomment the following lines to turn on 
 # verbose messages for debugging.
 # ophyd.logger.setLevel(logging.DEBUG)
 
 # diagnostics
-from bluesky.utils import ts_msg_hook
 #RE.msg_hook = ts_msg_hook
-from bluesky.simulators import summarize_plan
 
 # set default timeout for all EpicsSignalBase connections & communications
-from ophyd.signal import EpicsSignalBase
 EpicsSignalBase.set_default_timeout(timeout=10, connection_timeout=5)

--- a/profile_bluesky/startup/instrument/framework/initialize.py
+++ b/profile_bluesky/startup/instrument/framework/initialize.py
@@ -33,6 +33,7 @@ from IPython import get_ipython
 from ophyd.signal import EpicsSignalBase
 import databroker
 import os
+import warnings
 
 
 # convenience imports
@@ -87,5 +88,17 @@ bec.disable_baseline()
 # diagnostics
 # RE.msg_hook = ts_msg_hook
 
-# set default timeout for all EpicsSignalBase connections & communications
-EpicsSignalBase.set_default_timeout(timeout=10, connection_timeout=5)
+# set default timeout for all EpicsSignal connections & communications
+try:
+    EpicsSignalBase.set_defaults(
+        auto_monitor=True,
+        timeout=60,
+        write_timeout=60,
+        connection_timeout=5,
+    )
+except Exception as exc:
+    warnings.warn(
+        "ophyd version is old, upgrade to 1.6.0+ "
+        "to get set_defaults() method"
+    )
+    EpicsSignalBase.set_default_timeout(timeout=10, connection_timeout=5)

--- a/profile_bluesky/startup/instrument/framework/initialize.py
+++ b/profile_bluesky/startup/instrument/framework/initialize.py
@@ -52,8 +52,8 @@ RE.md = PersistentDict(
 # keep track of callback subscriptions
 callback_db = {}
 
-# Set up a Broker.
-db = databroker.Broker.named("mongodb_config")
+# Connect with mongodb database.
+db = databroker.catalog["mongodb_config"]
 
 # Subscribe metadatastore to documents.
 # If this is removed, data is not saved to metadatastore.

--- a/profile_bluesky/startup/instrument/framework/initialize.py
+++ b/profile_bluesky/startup/instrument/framework/initialize.py
@@ -1,18 +1,23 @@
-
 """
 initialize the bluesky framework
 """
 
 __all__ = [
-    'RE', 'db', 'sd',
-    'bec', 'peaks',
-    'bp', 'bps', 'bpp',
-    'summarize_plan',
-    'np',
-    'callback_db',
-    ]
+    "bec",
+    "bp",
+    "bpp",
+    "bps",
+    "callback_db",
+    "db",
+    "np",
+    "peaks",
+    "RE",
+    "sd",
+    "summarize_plan",
+]
 
 from ..session_logs import logger
+
 logger.info(__file__)
 
 from bluesky import RunEngine
@@ -47,11 +52,11 @@ RE.md = PersistentDict(
 callback_db = {}
 
 # Set up a Broker.
-db = databroker.Broker.named('mongodb_config')
+db = databroker.Broker.named("mongodb_config")
 
 # Subscribe metadatastore to documents.
 # If this is removed, data is not saved to metadatastore.
-callback_db['db'] = RE.subscribe(db.insert)
+callback_db["db"] = RE.subscribe(db.insert)
 
 # Set up SupplementalData.
 sd = SupplementalData()
@@ -66,20 +71,21 @@ get_ipython().register_magics(BlueskyMagics)
 
 # Set up the BestEffortCallback.
 bec = BestEffortCallback()
-callback_db['bec'] = RE.subscribe(bec)
+callback_db["bec"] = RE.subscribe(bec)
 peaks = bec.peaks  # just an alias, for less typing
 bec.disable_baseline()
 
 # At the end of every run, verify that files were saved and
 # print a confirmation message.
-# callback_db['post_run_verify'] = RE.subscribe(post_run(verify_files_saved), 'stop')
+# _prv_ = RE.subscribe(post_run(verify_files_saved), 'stop')
+# callback_db['post_run_verify'] = _prv_
 
-# Uncomment the following lines to turn on 
+# Uncomment the following lines to turn on
 # verbose messages for debugging.
 # ophyd.logger.setLevel(logging.DEBUG)
 
 # diagnostics
-#RE.msg_hook = ts_msg_hook
+# RE.msg_hook = ts_msg_hook
 
 # set default timeout for all EpicsSignalBase connections & communications
 EpicsSignalBase.set_default_timeout(timeout=10, connection_timeout=5)

--- a/profile_bluesky/startup/instrument/framework/initialize.py
+++ b/profile_bluesky/startup/instrument/framework/initialize.py
@@ -23,12 +23,12 @@ logger.info(__file__)
 from bluesky import RunEngine
 from bluesky import SupplementalData
 from bluesky.callbacks.best_effort import BestEffortCallback
-from bluesky.callbacks.broker import verify_files_saved
+# from bluesky.callbacks.broker import verify_files_saved
 from bluesky.magics import BlueskyMagics
 from bluesky.simulators import summarize_plan
 from bluesky.utils import PersistentDict
 from bluesky.utils import ProgressBarManager
-from bluesky.utils import ts_msg_hook
+# from bluesky.utils import ts_msg_hook
 from IPython import get_ipython
 from ophyd.signal import EpicsSignalBase
 import databroker

--- a/profile_bluesky/startup/instrument/framework/metadata.py
+++ b/profile_bluesky/startup/instrument/framework/metadata.py
@@ -7,6 +7,10 @@ __all__ = []
 from ..session_logs import logger
 logger.info(__file__)
 
+# required before hkl is imported
+import gi
+gi.require_version('Hkl', '5.0')
+
 import apstools
 import bluesky
 import databroker
@@ -14,6 +18,7 @@ from datetime import datetime
 import epics
 import getpass
 import h5py
+import hkl
 import matplotlib
 import numpy
 import ophyd
@@ -40,6 +45,8 @@ versions = dict(
     bluesky = bluesky.__version__,
     databroker = databroker.__version__,
     epics = epics.__version__,
+    h5py = h5py.__version__,
+    hklpy = hkl.__version__,
     matplotlib = matplotlib.__version__,
     numpy = numpy.__version__,
     ophyd = ophyd.__version__,


### PR DESCRIPTION
Fixes #60, includes updated `ophyd` support code affecting critical PV caching and timeout problems.  Also includes updates to `apstools`, `databroker, `bluesky`, and `hklpy` and many other packages.  Python 3.8.2.