### PR TITLE
Create stop method to energy

### DIFF
--- a/profile_bluesky/startup/instrument/devices/aps_source.py
+++ b/profile_bluesky/startup/instrument/devices/aps_source.py
@@ -89,6 +89,10 @@ class UndulatorEnergy(PVPositioner):
 
         return status
 
+    def stop(self, *, success=False):
+        self.parent.stop_button.put(1)
+        super().stop(success=success)
+
 
 class MyUndulator(ApsUndulator):
     """

--- a/profile_bluesky/startup/instrument/devices/aps_source.py
+++ b/profile_bluesky/startup/instrument/devices/aps_source.py
@@ -6,7 +6,7 @@ __all__ = ['aps', 'undulator']
 
 from apstools.devices import ApsMachineParametersDevice, ApsUndulator
 from ..framework import sd
-from .extra_signals import TrackingSignal, DoneSignal
+from .util_components import TrackingSignal, DoneSignal
 from ophyd import (Device, Component, Signal, EpicsSignal, EpicsSignalRO,
                    PVPositioner)
 from ophyd.status import Status, AndStatus, wait as status_wait

--- a/profile_bluesky/startup/instrument/devices/aps_source.py
+++ b/profile_bluesky/startup/instrument/devices/aps_source.py
@@ -42,8 +42,7 @@ class UndulatorEnergy(PVPositioner):
                         put_complete=True)
     actuate_value = 3
 
-    stop_signal = Component(EpicsSignal, "Stop.VAL", kind='omitted',
-                            put_complete=True)
+    stop_signal = Component(EpicsSignal, "Stop.VAL", kind='omitted')
     stop_value = 1
 
     # TODO: Does this work!?!?

--- a/profile_bluesky/startup/instrument/devices/energy.py
+++ b/profile_bluesky/startup/instrument/devices/energy.py
@@ -23,10 +23,10 @@ class EnergySignal(Signal):
     """
     def get(self, **kwargs):
         """ Uses the mono as the standard beamline energy. """
-        self._readback = mono.energy.get(**kwargs)
+        self._readback = mono.energy.readback.get(**kwargs)
         return self._readback
 
-    def set(self, position, *, wait=True, timeout=None, settle_time=None,
+    def set(self, position, *, wait=False, timeout=None, settle_time=None,
             moved_cb=None):
 
         # In case nothing needs to be moved, just create a finished status
@@ -34,9 +34,10 @@ class EnergySignal(Signal):
         status.set_finished()
 
         # Mono
-        if abs(self.get()-position) > mono.energy.tolerance:
-            mono_status = mono.energy.set(position, timeout=timeout,
-                                          settle_time=settle_time)
+        if abs(self.get()-position) > mono.energy.tolerance.get():
+            mono_status = mono.energy.set(
+                position, wait=wait, timeout=timeout, moved_cb=moved_cb
+            )
             status = AndStatus(status, mono_status)
 
         # Phase retarders
@@ -44,7 +45,7 @@ class EnergySignal(Signal):
             if pr.tracking.get():
                 pr_status = pr.energy.move(
                     position, wait=wait, timeout=timeout, moved_cb=moved_cb
-                    )
+                )
                 status = AndStatus(status, pr_status)
 
         # Undulator
@@ -52,7 +53,7 @@ class EnergySignal(Signal):
             und_pos = position + undulator.downstream.energy.offset.get()
             und_status = undulator.downstream.energy.move(
                 und_pos, wait=wait, timeout=timeout, moved_cb=moved_cb
-                )
+            )
             status = AndStatus(status, und_status)
 
         if wait:

--- a/profile_bluesky/startup/instrument/devices/energy.py
+++ b/profile_bluesky/startup/instrument/devices/energy.py
@@ -61,7 +61,9 @@ class EnergySignal(Signal):
         return status
 
     def stop(self, *, success=False):
-        # Stops everything regardless if it's tracking or not.
+        """
+        Stops all energy related devices regardless if it's tracking or not.
+        """
         for positioner in [mono, pr1, pr2, pr3, undulator.downstream]:
             positioner.energy.stop(success=success)
 

--- a/profile_bluesky/startup/instrument/devices/energy.py
+++ b/profile_bluesky/startup/instrument/devices/energy.py
@@ -60,7 +60,10 @@ class EnergySignal(Signal):
 
         return status
 
-    # TODO: Create stop method.
+    def stop(self, *, success=False):
+        # Stops everything regardless if it's tracking or not.
+        for positioner in [mono, pr1, pr2, pr3, undulator.downstream]:
+            positioner.energy.stop(success=success)
 
 
 energy = EnergySignal(name='energy', value=10, kind='hinted')

--- a/profile_bluesky/startup/instrument/devices/ge_controller.py
+++ b/profile_bluesky/startup/instrument/devices/ge_controller.py
@@ -8,7 +8,7 @@ from ophyd import Component
 from ophyd import EpicsSignalRO, EpicsSignalWithRBV
 from ophyd import FormattedComponent, PVPositioner
 from ophyd import Kind
-from .extra_signals import DoneSignal
+from .util_components import DoneSignal
 from ..framework import sd
 from ..session_logs import logger
 logger.info(__file__)

--- a/profile_bluesky/startup/instrument/devices/kepko.py
+++ b/profile_bluesky/startup/instrument/devices/kepko.py
@@ -7,7 +7,7 @@ __all__ = ['kepko']
 from ophyd import Component, FormattedComponent, Device, PVPositioner, Kind
 from ophyd import EpicsSignal, EpicsSignalRO
 from ..framework import sd
-from .extra_signals import DoneSignal
+from .util_components import DoneSignal
 
 from ..session_logs import logger
 logger.info(__file__)

--- a/profile_bluesky/startup/instrument/devices/lakeshore336.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore336.py
@@ -7,7 +7,7 @@ from ophyd import Component, Device, Staged
 from ophyd import EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
 from ophyd import FormattedComponent, PVPositioner
 from ophyd.status import wait as status_wait
-from .extra_signals import DoneSignal, TrackingSignal
+from .util_components import DoneSignal, TrackingSignal
 
 from instrument.session_logs import logger
 logger.info(__file__)

--- a/profile_bluesky/startup/instrument/devices/lakeshore340.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore340.py
@@ -6,7 +6,7 @@ from apstools.synApps.asyn import AsynRecord
 from ophyd import Component, Device, Signal, Staged
 from ophyd import EpicsSignal, EpicsSignalRO
 from ophyd import FormattedComponent, PVPositioner
-from .extra_signals import DoneSignal, TrackingSignal
+from .util_components import DoneSignal, TrackingSignal
 from time import sleep
 
 from instrument.session_logs import logger

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -99,6 +99,4 @@ class Monochromator(KohzuSeqCtl_Monochromator):
 
 mono = Monochromator('4idb:', name='mono')
 mono.stage_sigs['mode'] = 1  # Ensure that mono is in auto before moving.
-mono.energy.put_complete = True
-mono.wavelength.put_complete = True
 sd.baseline.append(mono)

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -35,12 +35,13 @@ class KohzuPositioner(PVPositionerSoftDone):
                  name=None, read_attrs=None, configuration_attrs=None,
                  parent=None, egu="", **kwargs):
 
-        # TODO: Ugly... but works.
-        _theta_pv_signal = EpicsSignalRO(f"{prefix}KohzuThetaPvSI", name="tmp")
-        _theta_pv_signal.wait_for_connection()
-        self._theta_pv = _theta_pv_signal.get(as_string=True)
-        _theta_pv_signal.destroy()
-        _theta_pv_signal = None
+        def get_th_pv():
+            _theta_pv_signal = EpicsSignalRO(f"{prefix}KohzuThetaPvSI",
+                                             name="tmp")
+            _theta_pv_signal.wait_for_connection()
+            return _theta_pv_signal.get(as_string=True)
+
+        self._theta_pv = get_th_pv()
 
         super().__init__(
             prefix, limits=limits, readback_pv=readback_pv,

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -7,7 +7,7 @@ __all__ = ['mono']
 from apstools.devices import KohzuSeqCtl_Monochromator
 from ophyd import (
     Component, Device, FormattedComponent, EpicsMotor, EpicsSignal,
-    EpicsSignalRO, PVPositioner
+    EpicsSignalRO
 )
 from .util_components import PVPositionerSoftDone
 from ..framework import sd
@@ -27,34 +27,6 @@ class MonoFeedback(Device):
 
 
 class KohzuPositioner(PVPositionerSoftDone):
-    stop_signal = FormattedComponent("{_stop_pv}.STOP", kind="omitted")
-    stop_value = 1
-
-    def __init__(self, prefix, *, limits=None, readback_pv="", setpoint_pv="",
-                 name=None, read_attrs=None, configuration_attrs=None,
-                 parent=None, egu="", **kwargs):
-
-        # TODO: Ugly... but works?
-        _theta_pv_signal = EpicsSignalRO(f"{prefix}KohzuThetaPvSI", name="tmp")
-        _theta_pv_signal.wait_for_connection()
-        self._theta_pv = _theta_pv_signal.get(as_string=True)
-        _theta_pv_signal.destroy()
-        _theta_pv_signal = None
-
-        super().__init__(
-            prefix, limits=limits, readback_pv=readback_pv,
-            setpoint_pv=setpoint_pv, name=name, read_attrs=read_attrs,
-            configuration_attrs=configuration_attrs, parent=parent, egu=egu,
-            **kwargs
-        )
-
-
-# TODO: OR!?!?
-class KohzuPositioner2(PVPositioner):
-
-    done = FormattedComponent("{_theta_pv}.DMOV", kind="omitted")
-    done_value = 1
-
     stop_signal = FormattedComponent("{_theta_pv}.STOP", kind="omitted")
     stop_value = 1
 
@@ -62,7 +34,7 @@ class KohzuPositioner2(PVPositioner):
                  name=None, read_attrs=None, configuration_attrs=None,
                  parent=None, egu="", **kwargs):
 
-        # TODO: Ugly... but works?
+        # TODO: Ugly... but works.
         _theta_pv_signal = EpicsSignalRO(f"{prefix}KohzuThetaPvSI", name="tmp")
         _theta_pv_signal.wait_for_connection()
         self._theta_pv = _theta_pv_signal.get(as_string=True)
@@ -81,16 +53,16 @@ class Monochromator(KohzuSeqCtl_Monochromator):
     """ Tweaks from apstools mono """
 
     wavelength = Component(
-        KohzuPositioner2, readback_pv="BraggLambdaRdbkAO",
+        KohzuPositioner, "", readback_pv="BraggLambdaRdbkAO",
         setpoint_pv="BraggLambdaAO"
     )
 
     energy = Component(
-        KohzuPositioner2, readback_pv="BraggERdbkAO", setpoint_pv="BraggEAO"
+        KohzuPositioner, "", readback_pv="BraggERdbkAO", setpoint_pv="BraggEAO"
     )
 
     theta = Component(
-        KohzuPositioner2, readback_pv="BraggThetaRdbkAO",
+        KohzuPositioner, "", readback_pv="BraggThetaRdbkAO",
         setpoint_pv="BraggThetaAO"
     )
 

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -27,7 +27,8 @@ class MonoFeedback(Device):
 
 
 class KohzuPositioner(PVPositionerSoftDone):
-    stop_signal = FormattedComponent("{_theta_pv}.STOP", kind="omitted")
+    stop_signal = FormattedComponent(EpicsSignal, "{_theta_pv}.STOP",
+                                     kind="omitted")
     stop_value = 1
 
     def __init__(self, prefix, *, limits=None, readback_pv="", setpoint_pv="",

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -27,21 +27,28 @@ class MonoFeedback(Device):
 
 
 class KohzuPositioner(PVPositionerSoftDone):
-    stop_signal = FormattedComponent(EpicsSignal, "{_theta_pv}.STOP",
-                                     kind="omitted")
-    stop_value = 1
+    stop_theta = FormattedComponent(EpicsSignal, "{_theta_pv}.STOP",
+                                    kind="omitted")
+    stop_y = FormattedComponent(EpicsSignal, "{_y_pv}.STOP",
+                                kind="omitted")
+    stop_z = FormattedComponent(EpicsSignal, "{_z_pv}.STOP",
+                                kind="omitted")
+
+    actuate = Component(EpicsSignal, "KohzuPutBO", kind="omitted")
+    actuate_value = 1
 
     def __init__(self, prefix, *, limits=None, readback_pv="", setpoint_pv="",
                  name=None, read_attrs=None, configuration_attrs=None,
                  parent=None, egu="", **kwargs):
 
-        def get_th_pv():
-            _theta_pv_signal = EpicsSignalRO(f"{prefix}KohzuThetaPvSI",
-                                             name="tmp")
-            _theta_pv_signal.wait_for_connection()
-            return _theta_pv_signal.get(as_string=True)
+        def get_motor_pv(label):
+            _pv_signal = EpicsSignalRO(f"{prefix}Kohzu{label}PvSI", name="tmp")
+            _pv_signal.wait_for_connection()
+            return _pv_signal.get(as_string=True)
 
-        self._theta_pv = get_th_pv()
+        self._theta_pv = get_motor_pv("Theta")
+        self._y_pv = get_motor_pv("Y")
+        self._z_pv = get_motor_pv("Z")
 
         super().__init__(
             prefix, limits=limits, readback_pv=readback_pv,
@@ -49,6 +56,11 @@ class KohzuPositioner(PVPositionerSoftDone):
             configuration_attrs=configuration_attrs, parent=parent, egu=egu,
             **kwargs
         )
+
+    def stop(self, *, success=False):
+        for motor in ["theta", "y", "z"]:
+            getattr(self, f"stop_{motor}").put(1, wait=False)
+        super().stop(success=success)
 
 
 class Monochromator(KohzuSeqCtl_Monochromator):

--- a/profile_bluesky/startup/instrument/devices/phaseplates.py
+++ b/profile_bluesky/startup/instrument/devices/phaseplates.py
@@ -11,7 +11,7 @@ from ophyd import EpicsSignal, EpicsSignalRO, Signal, DerivedSignal
 from ophyd.pseudopos import pseudo_position_argument, real_position_argument
 from scipy.constants import speed_of_light, Planck
 from numpy import arcsin, pi, sin
-from .extra_signals import TrackingSignal
+from .util_components import TrackingSignal
 from ..session_logs import logger
 
 # This is here because PRDevice.select_pr has a micron symbol that utf-8

--- a/profile_bluesky/startup/instrument/devices/ruby_motors.py
+++ b/profile_bluesky/startup/instrument/devices/ruby_motors.py
@@ -7,7 +7,7 @@ __all__ = ['ruby']
 from ophyd import (Component, Device, EpicsMotor, EpicsSignal, PVPositioner,
                    EpicsSignalRO, FormattedComponent)
 from ..framework import sd
-from .extra_signals import DoneSignal
+from .util_components import DoneSignal
 from ..session_logs import logger
 logger.info(__file__)
 

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -60,7 +60,7 @@ class PVPositionerSoftDone(PVPositioner):
     done = Component(Signal, value=True)
     done_value = True
 
-    tolerance = Component(Signal, value=0.001)
+    tolerance = Component(Signal, value=1)  # Value always updated during init.
     report_dmov_changes = Component(Signal, value=False, kind="omitted")
 
     def cb_readback(self, *args, **kwargs):

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -43,8 +43,8 @@ class TrackingSignal(Signal):
         ValueError
         """
         if not isinstance(value, bool):
-            raise ValueError('tracking is boolean, it can only be True or \
-                False.')
+            raise ValueError('tracking is boolean, it can only be True or '
+                             'False.')
 
 
 # TODO: Can we have readback_pv, setpoint_pv as *args? It looks

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -3,7 +3,10 @@
 Utilities
 """
 
-from ophyd import Signal, EpicsSignal, FormattedComponent
+from ophyd import (
+    Component, FormattedComponent, Signal, EpicsSignal, EpicsSignalRO,
+    PVPositioner
+)
 from ..session_logs import logger
 logger.info(__file__)
 
@@ -44,14 +47,53 @@ class TrackingSignal(Signal):
                 False.')
 
 
-class EpicsSignalwithStop(EpicsSignal):
-    stop_signal = FormattedComponent("{_stop_pv}", kind="omitted")
-    stop_value = 1
+# TODO: Can we have readback_pv, setpoint_pv as *args? It looks
+# like it doesn't work because it breaks the "name" while creating a
+# component?
+class PVPositionerSoftDone(PVPositioner):
 
-    def __init__(self, *args, stop_pv=None, stop_value=1, **kwargs):
-        self._stop_pv = stop_pv
-        super().__init__(*args, **kwargs)
-        self.stop_value = stop_value
+    # positioner
+    readback = FormattedComponent(EpicsSignalRO, "{prefix}{_readback_pv}",
+                                  kind="hinted", auto_monitor=True)
+    setpoint = FormattedComponent(EpicsSignal, "{prefix}{_setpoint_pv}",
+                                  kind="normal")
+    done = Component(Signal, value=True)
+    done_value = True
 
-    def stop(self, *, success=False):
-        self.stop_signal.put(self.stop_value, wait=False)
+    tolerance = Component(Signal, value=0.001)
+    report_dmov_changes = Component(Signal, value=False, kind="omitted")
+
+    def cb_readback(self, *args, **kwargs):
+        """
+        Called when readback changes (EPICS CA monitor event).
+        """
+        diff = self.readback.get() - self.setpoint.get()
+        dmov = abs(diff) <= self.tolerance.get()
+        if self.report_dmov_changes.get() and dmov != self.done.get():
+            logger.debug(f"{self.name} reached: {dmov}")
+        self.done.put(dmov)
+
+    def cb_setpoint(self, *args, **kwargs):
+        """
+        Called when setpoint changes (EPICS CA monitor event).
+        When the setpoint is changed, force done=False.  For any move,
+        done must go != done_value, then back to done_value (True).
+        Without this response, a small move (within tolerance) will not return.
+        Next update of readback will compute self.done.
+        """
+        self.done.put(not self.done_value)
+
+    def __init__(self, prefix, *, limits=None, readback_pv="", setpoint_pv="",
+                 name=None, read_attrs=None, configuration_attrs=None,
+                 parent=None, egu="", **kwargs):
+
+        self._setpoint_pv = setpoint_pv
+        self._readback_pv = readback_pv
+
+        super().__init__(prefix=prefix, limits=limits, name=name,
+                         read_attrs=read_attrs,
+                         configuration_attrs=configuration_attrs,
+                         parent=parent, egu=egu, **kwargs)
+
+        self.readback.subscribe(self.cb_readback)
+        self.setpoint.subscribe(self.cb_setpoint)

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -1,9 +1,9 @@
 
 """
-Convenient signals
+Utilities
 """
 
-from ophyd import Signal
+from ophyd import Signal, EpicsSignal, FormattedComponent
 from ..session_logs import logger
 logger.info(__file__)
 
@@ -42,3 +42,16 @@ class TrackingSignal(Signal):
         if not isinstance(value, bool):
             raise ValueError('tracking is boolean, it can only be True or \
                 False.')
+
+
+class EpicsSignalwithStop(EpicsSignal):
+    stop_signal = FormattedComponent("{_stop_pv}", kind="omitted")
+    stop_value = 1
+
+    def __init__(self, *args, stop_pv=None, stop_value=1, **kwargs):
+        self._stop_pv = stop_pv
+        super().__init__(*args, **kwargs)
+        self.stop_value = stop_value
+
+    def stop(self, *, success=False):
+        self.stop_signal.put(self.stop_value, wait=False)

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -108,3 +108,11 @@ class PVPositionerSoftDone(PVPositioner):
             tolerance = rb if rb >= sp else sp
 
         self.tolerance.put(tolerance)
+
+    def _setup_move(self, position):
+        '''Move and do not wait until motion is complete (asynchronous)'''
+        self.log.debug('%s.setpoint = %s', self.name, position)
+        self.setpoint.put(position, wait=False)
+        if self.actuate is not None:
+            self.log.debug('%s.actuate = %s', self.name, self.actuate_value)
+            self.actuate.put(self.actuate_value, wait=False)


### PR DESCRIPTION
Closes #97.

Creates adds stop methods to `EnergySignal`, `MyUndulator`, and `Monochromator`. The mono is the trickiest and ugliest solution. The EPICS Kohzu screen exposes the `mono.th` PV in a PV. So the critical part (and perhaps problematic) part is this:

```python
class KohzuPositioner(PVPositionerSoftDone):
    stop_signal = FormattedComponent(EpicsSignal, "{_theta_pv}.STOP",
                                     kind="omitted")
    stop_value = 1

    def __init__(self, prefix, *, limits=None, readback_pv="", setpoint_pv="",
                 name=None, read_attrs=None, configuration_attrs=None,
                 parent=None, egu="", **kwargs):

        # TODO: Ugly... but works.
        _theta_pv_signal = EpicsSignalRO(f"{prefix}KohzuThetaPvSI", name="tmp")
        _theta_pv_signal.wait_for_connection()
        self._theta_pv = _theta_pv_signal.get(as_string=True)
        _theta_pv_signal.destroy()
        _theta_pv_signal = None

        super().__init__(
            prefix, limits=limits, readback_pv=readback_pv,
            setpoint_pv=setpoint_pv, name=name, read_attrs=read_attrs,
            configuration_attrs=configuration_attrs, parent=parent, egu=egu,
            **kwargs
        )
```

@prjemian: any alternative solution?