### PR TITLE
Change PVPositionerSoftDone

### DIFF
--- a/profile_bluesky/startup/instrument/devices/aps_source.py
+++ b/profile_bluesky/startup/instrument/devices/aps_source.py
@@ -59,6 +59,10 @@ class UndulatorEnergy(PVPositioner):
         self.setpoint.subscribe(self.done.get)
         self._status_obj = Status(self)
 
+        # Make the default alias for the readback the name of the
+        # positioner itself as in EpicsMotor.
+        self.readback.name = self.name
+
     @deadband.sub_value
     def _change_tolerance(self, value=None, **kwargs):
         if value:

--- a/profile_bluesky/startup/instrument/devices/aps_source.py
+++ b/profile_bluesky/startup/instrument/devices/aps_source.py
@@ -22,7 +22,9 @@ sd.baseline.append(aps)
 class UndulatorEnergy(PVPositioner):
     """
     Undulator energy positioner.
-    Main purpose this being a PVPositioner is to handle the undulator backlash.
+
+    Always move the undulator to final position from the high to low energy
+    direction, by applying a backlash (hysteresis) correction as needed.
     """
 
     # Position
@@ -70,15 +72,18 @@ class UndulatorEnergy(PVPositioner):
     def move(self, position, wait=True, **kwargs):
         """
         Moves the undulator energy.
+
         Currently, the backlash has to be handled within Bluesky. The actual
         motion is done by `self._move` using threading. kwargs are passed to
         PVPositioner.move().
+
         Parameters
         ----------
         position : float
             Position to move to
         wait : boolean, optional
             Flag to block the execution until motion is completed.
+
         Returns
         -------
         status : Status
@@ -104,7 +109,8 @@ class UndulatorEnergy(PVPositioner):
     def _move(self, position, **kwargs):
         """
         Moves undulator.
-        This is meant to the ran using threading, so the move will block by
+
+        This is meant to the be ran using threading, so the move will block by
         construction.
         """
 
@@ -135,6 +141,7 @@ class UndulatorEnergy(PVPositioner):
 class MyUndulator(ApsUndulator):
     """
     Undulator setup.
+
     Differences from `apstools` standard:
     - `energy` is a PVPositioner.
     - `start_button`, `stop_button` and `device_status` go into `energy`.

--- a/profile_bluesky/startup/instrument/devices/aps_source.py
+++ b/profile_bluesky/startup/instrument/devices/aps_source.py
@@ -114,7 +114,7 @@ class UndulatorEnergy(PVPositioner):
         """
         Moves undulator.
 
-        This is meant to the be ran using threading, so the move will block by
+        This is meant to run using threading, so the move will block by
         construction.
         """
 

--- a/profile_bluesky/startup/instrument/devices/aps_source.py
+++ b/profile_bluesky/startup/instrument/devices/aps_source.py
@@ -6,10 +6,12 @@ __all__ = ['aps', 'undulator']
 
 from apstools.devices import ApsMachineParametersDevice, ApsUndulator
 from ..framework import sd
-from .util_components import TrackingSignal, PVPositionerSoftDone
-from ophyd import Device, Component, Signal
-from ophyd.status import Status, AndStatus, wait as status_wait
-
+from .util_components import TrackingSignal
+from ophyd import (Device, Component, Signal, EpicsSignal, EpicsSignalRO,
+                   PVPositioner)
+from ophyd.status import Status, wait as status_wait
+from ophyd.utils import InvalidState
+from threading import Thread
 from ..session_logs import logger
 logger.info(__file__)
 
@@ -17,78 +19,135 @@ aps = ApsMachineParametersDevice(name="aps")
 sd.baseline.append(aps)
 
 
-class UndulatorEnergy(PVPositionerSoftDone):
+class UndulatorEnergy(PVPositioner):
     """
     Undulator energy positioner.
-
     Main purpose this being a PVPositioner is to handle the undulator backlash.
     """
+
+    # Position
+    readback = Component(EpicsSignalRO, 'Energy', kind='hinted',
+                         auto_monitor=True)
+    setpoint = Component(EpicsSignal, 'EnergySet', put_complete=True,
+                         auto_monitor=True, kind='normal')
 
     # Configuration
     deadband = Component(Signal, value=0.002, kind='config')
     backlash = Component(Signal, value=0.25, kind='config')
     offset = Component(Signal, value=0, kind='config')
 
+    # Buttons
+    actuate = Component(EpicsSignal, "Start.VAL", kind='omitted',
+                        put_complete=True)
+    actuate_value = 3
+
+    stop_signal = Component(EpicsSignal, "Stop.VAL", kind='omitted')
+    stop_value = 1
+
+    # TODO: Does this work!?!?
+    # done = Component(DoneSignal, value=0, kind='omitted')
+    # done_value = 1
+    done = Component(EpicsSignal, "Busy.VAL", kind="omitted")
+    done_value = 0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tolerance = 0.002
+        self.readback.subscribe(self.done.get)
+        self.setpoint.subscribe(self.done.get)
+        self._status_obj = Status(self)
+
     @deadband.sub_value
     def _change_tolerance(self, value=None, **kwargs):
         if value:
             self.tolerance = value
 
+    # TODO: This is unnecessary if use done EpicsSignal.
+    # @done.sub_value
+    # def _move_changed(self, **kwargs):
+    #     super()._move_changed(**kwargs)
+
     def move(self, position, wait=True, **kwargs):
+        """
+        Moves the undulator energy.
+        Currently, the backlash has to be handled within Bluesky. The actual
+        motion is done by `self._move` using threading. kwargs are passed to
+        PVPositioner.move().
+        Parameters
+        ----------
+        position : float
+            Position to move to
+        wait : boolean, optional
+            Flag to block the execution until motion is completed.
+        Returns
+        -------
+        status : Status
+        """
+
+        self._status_obj = Status(self)
 
         # If position is in the the deadband -> do nothing.
         if abs(position - self.readback.get()) <= self.tolerance:
-            status = Status(self)
-            status.set_finished()
+            self._status_obj.set_finished()
+
         # Otherwise -> let's move!
         else:
+            thread = Thread(target=self._move, args=(position,),
+                            kwargs=kwargs)
+            thread.start()
 
-            # Applies backlash if needed.
-            if position > self.readback.get():
-                # Go to backlash position, wait until it gets there.
-                # TODO: is there a way to run these two actions without
-                # blocking? The undulator would still move to the backlash
-                # position, then final position, but the user would be able to
-                # use the terminal.
-
-                first_pos_status = super().move(position + self.backlash.get(),
-                                                wait=False, **kwargs)
-                first_click_status = self.parent.start_button.set(1)
-                first_status = AndStatus(first_pos_status, first_click_status)
-                status_wait(first_status)
-
-            timeout = kwargs.pop('timeout', 120)
-            pos_status = super().move(position, wait=False, timeout=timeout,
-                                      **kwargs)
-            click_status = self.parent.start_button.set(1)
-            status = AndStatus(pos_status, click_status)
-        self.cb_readback()
         if wait:
-            status_wait(status)
+            status_wait(self._status_obj)
 
-        return status
+        return self._status_obj
+
+    def _move(self, position, **kwargs):
+        """
+        Moves undulator.
+        This is meant to the ran using threading, so the move will block by
+        construction.
+        """
+
+        # Applies backlash if needed.
+        if position > self.readback.get():
+            self._move_and_wait(position + self.backlash.get(), **kwargs)
+
+        # Check if stop was requested during first part of the motion.
+        if not self._status_obj.done:
+            self._move_and_wait(position, **kwargs)
+            self._finish_status()
+
+    def _move_and_wait(self, position, **kwargs):
+        status = super().move(position, wait=False, **kwargs)
+        status_wait(status)
+
+    def _finish_status(self):
+        try:
+            self._status_obj.set_finished()
+        except InvalidState:
+            pass
 
     def stop(self, *, success=False):
-        self.parent.stop_button.put(1)
         super().stop(success=success)
+        self._finish_status()
 
 
 class MyUndulator(ApsUndulator):
     """
     Undulator setup.
-
     Differences from `apstools` standard:
-    - energy is a PVPositioner.
+    - `energy` is a PVPositioner.
+    - `start_button`, `stop_button` and `device_status` go into `energy`.
     - Has a flag used to track the mono energy.
     - Has an interactive undulator_setup.
     """
 
-    energy = Component(
-        UndulatorEnergy, '', readback_pv='Energy', setpoint_pv='EnergySet',
-        tolerance=0.002
-    )
-
+    energy = Component(UndulatorEnergy, '')
     tracking = Component(TrackingSignal, value=False, kind='config')
+
+    start_button = None
+    stop_button = None
+    device_status = None
 
     def undulator_setup(self):
         """Interactive setup of usual undulator parameters."""

--- a/profile_bluesky/startup/instrument/devices/ge_controller.py
+++ b/profile_bluesky/startup/instrument/devices/ge_controller.py
@@ -15,13 +15,13 @@ class GEController(PVPositionerSoftDone):
     """ General controller as a PVPositioner """
 
     # configuration
-    units = Component(EpicsSignalWithRBV, "{self.prefix}Units", kind="config")
-    control = Component(EpicsSignalWithRBV, "{self.prefix}Control",
+    units = Component(EpicsSignalWithRBV, "Units", kind="config")
+    control = Component(EpicsSignalWithRBV, "Control",
                         kind="config")
-    slew_mode = Component(EpicsSignalWithRBV, "{self.prefix}SlewMode",
+    slew_mode = Component(EpicsSignalWithRBV, "SlewMode",
                           kind="config")
-    slew = Component(EpicsSignalWithRBV, "{self.prefix}Slew", kind="config")
-    effort = Component(EpicsSignalRO, "{self.prefix}Effort_RBV",
+    slew = Component(EpicsSignalWithRBV, "Slew", kind="config")
+    effort = Component(EpicsSignalRO, "Effort_RBV",
                        auto_monitor=True, kind="config")
 
     def __init__(self, *args, timeout=60*60*10, **kwargs):

--- a/profile_bluesky/startup/instrument/devices/ge_controller.py
+++ b/profile_bluesky/startup/instrument/devices/ge_controller.py
@@ -4,53 +4,29 @@ GE pressure controllers
 
 __all__ = ['ge_apply', 'ge_release']
 
-from ophyd import Component
-from ophyd import EpicsSignalRO, EpicsSignalWithRBV
-from ophyd import FormattedComponent, PVPositioner
-from ophyd import Kind
-from .util_components import DoneSignal
+from ophyd import Component, EpicsSignalRO, EpicsSignalWithRBV
+from .util_components import PVPositionerSoftDone
 from ..framework import sd
 from ..session_logs import logger
 logger.info(__file__)
 
 
-class GEController(PVPositioner):
+class GEController(PVPositionerSoftDone):
     """ General controller as a PVPositioner """
 
-    # position
-    readback = FormattedComponent(EpicsSignalRO, "{self.prefix}Pressure_RBV",
-                                  auto_monitor=True, kind=Kind.hinted)
-    setpoint = FormattedComponent(EpicsSignalWithRBV, "{self.prefix}Setpoint",
-                                  auto_monitor=True, kind=Kind.normal)
-
-    # status
-    done = Component(DoneSignal, value=0, kind=Kind.omitted)
-    done_value = 1
-
     # configuration
-    units = FormattedComponent(EpicsSignalWithRBV, "{self.prefix}Units",
-                               kind=Kind.config)
+    units = Component(EpicsSignalWithRBV, "{self.prefix}Units", kind="config")
+    control = Component(EpicsSignalWithRBV, "{self.prefix}Control",
+                        kind="config")
+    slew_mode = Component(EpicsSignalWithRBV, "{self.prefix}SlewMode",
+                          kind="config")
+    slew = Component(EpicsSignalWithRBV, "{self.prefix}Slew", kind="config")
+    effort = Component(EpicsSignalRO, "{self.prefix}Effort_RBV",
+                       auto_monitor=True, kind="config")
 
-    control = FormattedComponent(EpicsSignalWithRBV, "{self.prefix}Control",
-                                 kind=Kind.config)
-
-    slew_mode = FormattedComponent(EpicsSignalWithRBV, "{self.prefix}SlewMode",
-                                   kind=Kind.config)
-
-    slew = FormattedComponent(EpicsSignalWithRBV, "{self.prefix}Slew",
-                              kind=Kind.config)
-
-    effort = FormattedComponent(EpicsSignalRO, "{self.prefix}Effort_RBV",
-                                auto_monitor=True, kind=Kind.config)
-
-    def __init__(self, *args, loop_number=None, timeout=60*60*10, **kwargs):
-        self.loop_number = loop_number
+    def __init__(self, *args, timeout=60*60*10, **kwargs):
         super().__init__(*args, timeout=timeout, **kwargs)
         self._settle_time = 0
-        self._tolerance = 0.01
-
-        self.readback.subscribe(self.done.get)
-        self.setpoint.subscribe(self.done.get)
 
     @property
     def settle_time(self):
@@ -64,18 +40,6 @@ class GEController(PVPositioner):
             self._settle_time = value
 
     @property
-    def tolerance(self):
-        return self._tolerance
-
-    @tolerance.setter
-    def tolerance(self, value):
-        if value < 0:
-            raise ValueError('Tolerance needs to be >= 0.')
-        else:
-            self._tolerance = value
-            _ = self.done.get()
-
-    @property
     def egu(self):
         return self.units.get(as_string=True)
 
@@ -84,25 +48,15 @@ class GEController(PVPositioner):
             self.setpoint.put(self._position)
         super().stop(success=success)
 
-    def pause(self):
-        self.setpoint.put(self._position)
 
-    @done.sub_value
-    def _move_changed(self, **kwargs):
-        super()._move_changed(**kwargs)
-
-    def move(self, *args, **kwargs):
-        # TODO: This self.done.put(0) is for the cases where the end point is
-        # within self.tolerance. Is it needed? Or is there a better way to do
-        # this?
-        self.done.put(0)
-        return super().move(*args, **kwargs)
-
-
-ge_apply = GEController("4idd:PC1:", name="ge_apply",
-                        labels=('ge_controller',))
-ge_release = GEController("4idd:PC2:", name="ge_release",
-                          labels=('ge_controller',))
+ge_apply = GEController(
+    "4idd:PC1:", name="ge_apply", readback_pv="Pressure_RBV",
+    setpoint_pv="Setpoint", tolerance=0.01, labels=('ge_controller',)
+)
+ge_release = GEController(
+    "4idd:PC2:", name="ge_release", readback_pv="Pressure_RBV",
+    setpoint_pv="Setpoint", tolerance=0.01, labels=('ge_controller',)
+)
 
 sd.baseline.append(ge_apply)
 sd.baseline.append(ge_release)

--- a/profile_bluesky/startup/instrument/devices/high_field_magnet.py
+++ b/profile_bluesky/startup/instrument/devices/high_field_magnet.py
@@ -87,6 +87,12 @@ class AMIController(PVPositioner):
 
     stop_signal = pause_button
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Make the default alias for the readback the name of the
+        # positioner itself as in EpicsMotor.
+        self.readback.name = self.name
+
     @property
     def egu(self):
         return self.units.get(as_string=True)

--- a/profile_bluesky/startup/instrument/devices/high_field_magnet.py
+++ b/profile_bluesky/startup/instrument/devices/high_field_magnet.py
@@ -4,10 +4,8 @@
 
 __all__ = ['mag6t']
 
-from ophyd import Component, Device, EpicsMotor, PVPositioner
-from ophyd import EpicsSignal, EpicsSignalRO, Signal
-from ophyd import Kind
-from ophyd.status import wait as status_wait
+from ophyd import (Component, Device, EpicsMotor, PVPositioner, EpicsSignal,
+                   EpicsSignalRO, Signal)
 from ..framework import sd
 from ..session_logs import logger
 logger.info(__file__)
@@ -15,9 +13,9 @@ logger.info(__file__)
 
 class AMIZones(Device):
     high_field = Component(EpicsSignal, "Field.VAL", write_pv="FieldSet",
-                           kind=Kind.config)
+                           kind="config")
     ramp_rate = Component(EpicsSignal, "Rate", write_pv="RateSet",
-                          kind=Kind.config)
+                          kind="config")
 
 
 class AMIController(PVPositioner):
@@ -25,115 +23,73 @@ class AMIController(PVPositioner):
 
     # position
     readback = Component(EpicsSignalRO, "Field", auto_monitor=True,
-                         kind=Kind.hinted,
-                         labels=('ami_controller', 'magnets'))
+                         kind="hinted", labels=('ami_controller', 'magnets'))
 
     setpoint = Component(EpicsSignal, "PField", write_pv="PField:Wrt.A",
-                         auto_monitor=True, kind=Kind.normal,
+                         auto_monitor=True, kind="normal",
                          labels=('ami_controller', 'magnets'))
 
     current = Component(EpicsSignalRO, "Current", auto_monitor=True,
-                        kind=Kind.normal, labels=('ami_controller', 'magnets'))
+                        kind="normal", labels=('ami_controller', 'magnets'))
 
     voltage = Component(EpicsSignalRO, "Voltage", auto_monitor=True,
-                        kind=Kind.normal, labels=('ami_controller', 'magnets'))
+                        kind="normal", labels=('ami_controller', 'magnets'))
 
-    supply_current = Component(EpicsSignalRO, "CurrentSP", auto_monitor=True,
-                               kind=Kind.normal,
-                               labels=('ami_controller', 'magnets'))
+    supply_current = Component(
+        EpicsSignalRO, "CurrentSP", auto_monitor=True, kind="normal",
+        labels=('ami_controller', 'magnets')
+    )
+
     # status
-    magnet_status = Component(EpicsSignalRO, "StateInt.A", auto_monitor=True,
-                              kind=Kind.config,
-                              labels=('ami_controller', 'magnets'))
+    magnet_status = Component(
+        EpicsSignalRO, "StateInt.A", auto_monitor=True, kind="config",
+        labels=('ami_controller', 'magnets')
+    )
 
     done = magnet_status
     done_value = 2
 
     # configuration
-    units = Component(EpicsSignalRO, "FieldUnits.SVAL", kind=Kind.config,
+    units = Component(EpicsSignalRO, "FieldUnits.SVAL", kind="config",
                       labels=('ami_controller', 'magnets'))
 
-    field_limit = Component(EpicsSignalRO, "Field:Limit", kind=Kind.config,
+    field_limit = Component(EpicsSignalRO, "Field:Limit", kind="config",
                             labels=('ami_controller', 'magnets'))
     current_limit = Component(EpicsSignalRO, "Curr:Limit.VAL",
-                              kind=Kind.config,
+                              kind="config",
                               labels=('ami_controller', 'magnets'))
     voltage_limit = Component(EpicsSignalRO, "Volt:Limit.VAL",
-                              kind=Kind.config,
+                              kind="config",
                               labels=('ami_controller', 'magnets'))
 
     switch_heater = Component(EpicsSignal, "PSOnOff", string=True,
-                              kind=Kind.config,
+                              kind="config",
                               labels=('ami_controller', 'magnets'))
 
-    zone_1 = Component(AMIZones, "RampR1:", kind=Kind.config,
+    zone_1 = Component(AMIZones, "RampR1:", kind="config",
                        labels=('ami_controller', 'magnets'))
-    zone_2 = Component(AMIZones, "RampR2:", kind=Kind.config,
+    zone_2 = Component(AMIZones, "RampR2:", kind="config",
                        labels=('ami_controller', 'magnets'))
-    zone_3 = Component(AMIZones, "RampR3:", kind=Kind.config,
+    zone_3 = Component(AMIZones, "RampR3:", kind="config",
                        labels=('ami_controller', 'magnets'))
-    ramp_units = Component(EpicsSignalRO, "RampR:Units.SVAL", kind=Kind.config,
+    ramp_units = Component(EpicsSignalRO, "RampR:Units.SVAL", kind="config",
                            labels=('ami_controller', 'magnets'))
-    tolerance = Component(Signal, value=0.0005, kind=Kind.config,
+    tolerance = Component(Signal, value=0.0005, kind="config",
                           labels=('ami_controller', 'magnets'))
 
     # Buttons
-    ramp_button = Component(EpicsSignal, "Ramp.PROC", kind=Kind.omitted,
+    ramp_button = Component(EpicsSignal, "Ramp.PROC", kind="omitted",
                             put_complete=True)
-    pause_button = Component(EpicsSignal, "Pause.PROC", kind=Kind.omitted,
+    pause_button = Component(EpicsSignal, "Pause.PROC", kind="omitted",
                              put_complete=True)
-    zero_button = Component(EpicsSignal, "Zero.PROC", kind=Kind.omitted,
+    zero_button = Component(EpicsSignal, "Zero.PROC", kind="omitted",
                             put_complete=True)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._settle_time = 0
-
-    @property
-    def settle_time(self):
-        return self._settle_time
-
-    @settle_time.setter
-    def settle_time(self, value):
-        if value < 0:
-            raise ValueError('Settle value needs to be >= 0.')
-        else:
-            self._settle_time = value
+    stop_signal = pause_button
 
     @property
     def egu(self):
         return self.units.get(as_string=True)
-
-    def stop(self, *, success=False):
-        if success is False:
-            self.pause_button.put(1)
-        super().stop(success=success)
-
-    def pause(self):
-        self.pause_button.put(1)
-
-    @done.sub_value
-    def _move_changed(self, **kwargs):
-        super()._move_changed(**kwargs)
-
-    def move(self, position, wait=True, **kwargs):
-
-        _current_pos = self.readback.get()
-
-        status = super().move(position, wait=False, **kwargs)
-
-        if abs(position-_current_pos) < self.tolerance.get():
-            self._done_moving()
-        else:
-            try:
-                self._setup_move(position)
-                if wait:
-                    status_wait(status)
-            except KeyboardInterrupt:
-                self.stop()
-                raise
-
-        return status
 
 
 # Magnet and sample motors

--- a/profile_bluesky/startup/instrument/devices/lakeshore336.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore336.py
@@ -120,6 +120,11 @@ class LS336_LoopControl(PVPositionerSoftDone):
     def pause(self):
         self.setpoint.put(self._position)
 
+    def move(self, position, **kwargs):
+        # Need to update the target.
+        self.target.put(position)
+        return super().move(position, **kwargs)
+
     @auto_heater.sub_value
     def _subscribe_auto_heater(self, value=None, **kwargs):
         if value:

--- a/profile_bluesky/startup/instrument/devices/lakeshore336.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore336.py
@@ -8,7 +8,7 @@ from ophyd import (Component, FormattedComponent, Device, EpicsSignal, Signal,
 from ophyd.status import wait as status_wait
 from .util_components import TrackingSignal, PVPositionerSoftDone
 
-from instrument.session_logs import logger
+from ..session_logs import logger
 logger.info(__file__)
 
 

--- a/profile_bluesky/startup/instrument/devices/lakeshore340.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore340.py
@@ -100,6 +100,11 @@ class LS340_LoopBase(PVPositionerSoftDone):
     def egu(self):
         return self.units.get(as_string=True)
 
+    def stop(self, *, success=False):
+        if success is False:
+            self.setpoint.put(self._position)
+        super().stop(success=success)
+
     def pause(self):
         self.setpoint.put(self._position, wait=True)
 
@@ -112,21 +117,15 @@ class LS340_LoopBase(PVPositionerSoftDone):
 class LS340_LoopControl(LS340_LoopBase):
     """ Control specific """
 
-    # TODO: why FormattedComponent!?!?
-    readback = FormattedComponent(EpicsSignalRO, "{prefix}Control",
-                                  kind="normal")
-    sensor = FormattedComponent(EpicsSignal, "{prefix}Ctl_sel",
-                                kind="config")
+    readback = Component(EpicsSignalRO, "Control", kind="normal")
+    sensor = Component(EpicsSignal, "Ctl_sel", kind="config")
 
 
 class LS340_LoopSample(LS340_LoopBase):
     """ Sample specific """
 
-    # TODO: why FormattedComponent!?!?
-    readback = FormattedComponent(EpicsSignalRO, "{prefix}Sample",
-                                  kind="hinted")
-    sensor = FormattedComponent(EpicsSignal, "{prefix}Spl_sel",
-                                kind="config")
+    readback = Component(EpicsSignalRO, "Sample", kind="hinted")
+    sensor = Component(EpicsSignal, "Spl_sel", kind="config")
 
 
 class LS340Device(Device):

--- a/profile_bluesky/startup/instrument/devices/lakeshore340.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore340.py
@@ -8,7 +8,7 @@ from ophyd import (Component, Device, Signal, EpicsSignal, EpicsSignalRO,
 from .util_components import PVPositionerSoftDone, TrackingSignal
 from time import sleep
 
-from instrument.session_logs import logger
+from ..session_logs import logger
 logger.info(__file__)
 
 

--- a/profile_bluesky/startup/instrument/devices/lakeshores.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshores.py
@@ -8,7 +8,7 @@ from .lakeshore336 import LS336Device
 from .lakeshore340 import LS340Device
 from ..framework import sd
 
-from instrument.session_logs import logger
+from ..session_logs import logger
 logger.info(__file__)
 
 # Lakeshore 336

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -35,12 +35,13 @@ class KohzuPositioner(PVPositionerSoftDone):
                  name=None, read_attrs=None, configuration_attrs=None,
                  parent=None, egu="", **kwargs):
 
-        # TODO: Ugly... but works.
-        _theta_pv_signal = EpicsSignalRO(f"{prefix}KohzuThetaPvSI", name="tmp")
-        _theta_pv_signal.wait_for_connection()
-        self._theta_pv = _theta_pv_signal.get(as_string=True)
-        _theta_pv_signal.destroy()
-        _theta_pv_signal = None
+        def get_th_pv():
+            _theta_pv_signal = EpicsSignalRO(f"{prefix}KohzuThetaPvSI",
+                                             name="tmp")
+            _theta_pv_signal.wait_for_connection()
+            return _theta_pv_signal.get(as_string=True)
+
+        self._theta_pv = get_th_pv()
 
         super().__init__(
             prefix, limits=limits, readback_pv=readback_pv,

--- a/profile_bluesky/startup/instrument/devices/ruby_motors.py
+++ b/profile_bluesky/startup/instrument/devices/ruby_motors.py
@@ -4,46 +4,26 @@ Ruby spectrometer motors and controls.
 
 __all__ = ['ruby']
 
-from ophyd import (Component, Device, EpicsMotor, EpicsSignal, PVPositioner,
-                   EpicsSignalRO, FormattedComponent)
+from ophyd import (Component, Device, EpicsMotor, EpicsSignal, EpicsSignalRO,
+                   FormattedComponent)
 from ..framework import sd
-from .util_components import DoneSignal
+from .util_components import PVPositionerSoftDone
 from ..session_logs import logger
 logger.info(__file__)
 
 
-class DAC(PVPositioner):
+class DAC(PVPositionerSoftDone):
     """ Setup DAC as a PVPositioner """
 
     setpoint = Component(EpicsSignal, '.VAL', put_complete=True, kind='normal')
     readback = Component(EpicsSignalRO, '_rbv.VAL', auto_monitor=True,
                          kind='hinted')
 
-    done = Component(DoneSignal, value=1)
-    done_value = 1
-
     low_limit = Component(EpicsSignal, '.DRVL', kind='config')
     high_limit = Component(EpicsSignal, '.DRVH', kind='config')
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self._tolerance = 0.001
-
-        self.readback.subscribe(self.done.get)
-        self.setpoint.subscribe(self.done.get)
-
-    @property
-    def tolerance(self):
-        return self._tolerance
-
-    @tolerance.setter
-    def tolerance(self, value):
-        if value < 0:
-            raise ValueError('Tolerance needs to be >= 0.')
-        else:
-            self._tolerance = value
-            _ = self.done.get()
+        super().__init__(*args, tolerance=0.001, **kwargs)
 
     @property
     def limits(self):

--- a/profile_bluesky/startup/instrument/devices/slits.py
+++ b/profile_bluesky/startup/instrument/devices/slits.py
@@ -3,60 +3,11 @@ Slits
 """
 __all__ = ['wbslt', 'enslt', 'inslt', 'grdslt', 'detslt', 'magslt']
 
-from ophyd import (Device, EpicsMotor, EpicsSignal, EpicsSignalRO, Signal,
-                   FormattedComponent, PVPositioner, Component)
+from ophyd import Device, FormattedComponent, EpicsMotor
+from .util_components import PVPositionerSoftDone
 from ..framework import sd
 from ..session_logs import logger
 logger.info(__file__)
-
-
-class PVPositionerSoftDone(PVPositioner):
-
-    # positioner
-    readback = FormattedComponent(EpicsSignalRO, "{prefix}{_readback_pv}",
-                                  kind="hinted", auto_monitor=True)
-    setpoint = FormattedComponent(EpicsSignal, "{prefix}{_setpoint_pv}",
-                                  kind="normal")
-    done = Component(Signal, value=True)
-    done_value = True
-
-    tolerance = Component(Signal, value=0.001)
-    report_dmov_changes = Component(Signal, value=False, kind="omitted")
-
-    def cb_readback(self, *args, **kwargs):
-        """
-        Called when readback changes (EPICS CA monitor event).
-        """
-        diff = self.readback.get() - self.setpoint.get()
-        dmov = abs(diff) <= self.tolerance.get()
-        if self.report_dmov_changes.get() and dmov != self.done.get():
-            logger.debug(f"{self.name} reached: {dmov}")
-        self.done.put(dmov)
-
-    def cb_setpoint(self, *args, **kwargs):
-        """
-        Called when setpoint changes (EPICS CA monitor event).
-        When the setpoint is changed, force done=False.  For any move,
-        done must go != done_value, then back to done_value (True).
-        Without this response, a small move (within tolerance) will not return.
-        Next update of readback will compute self.done.
-        """
-        self.done.put(not self.done_value)
-
-    def __init__(self, prefix, *, limits=None, readback_pv="", setpoint_pv="",
-                 name=None, read_attrs=None, configuration_attrs=None,
-                 parent=None, egu="", **kwargs):
-
-        self._setpoint_pv = setpoint_pv
-        self._readback_pv = readback_pv
-
-        super().__init__(prefix=prefix, limits=limits, name=name,
-                         read_attrs=read_attrs,
-                         configuration_attrs=configuration_attrs,
-                         parent=parent, egu=egu, **kwargs)
-
-        self.readback.subscribe(self.cb_readback)
-        self.setpoint.subscribe(self.cb_setpoint)
 
 
 class SlitDevice(Device):

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -43,8 +43,8 @@ class TrackingSignal(Signal):
         ValueError
         """
         if not isinstance(value, bool):
-            raise ValueError('tracking is boolean, it can only be True or \
-                False.')
+            raise ValueError('tracking is boolean, it can only be True or '
+                             'False.')
 
 
 # TODO: Can we have readback_pv, setpoint_pv as *args? It looks

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -97,6 +97,10 @@ class PVPositionerSoftDone(PVPositioner):
                          configuration_attrs=configuration_attrs,
                          parent=parent, egu=egu, **kwargs)
 
+        # Make the default alias for the readback the name of the
+        # positioner itself as in EpicsMotor.
+        self.readback.name = self.name
+
         self.readback.subscribe(self.cb_readback)
         self.setpoint.subscribe(self.cb_setpoint)
 

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -67,7 +67,7 @@ class PVPositionerSoftDone(PVPositioner):
         """
         Called when readback changes (EPICS CA monitor event).
         """
-        diff = self.readback.get() - self.setpoint.get()
+        diff = self.readback.get() - getattr(self, self._target_attr).get()
         dmov = abs(diff) <= self.tolerance.get()
         if self.report_dmov_changes.get() and dmov != self.done.get():
             logger.debug(f"{self.name} reached: {dmov}")
@@ -85,10 +85,12 @@ class PVPositionerSoftDone(PVPositioner):
 
     def __init__(self, prefix, *, limits=None, readback_pv="", setpoint_pv="",
                  name=None, read_attrs=None, configuration_attrs=None,
-                 parent=None, egu="", tolerance=None, **kwargs):
+                 parent=None, egu="", tolerance=None, target_attr="setpoint",
+                 **kwargs):
 
         self._setpoint_pv = setpoint_pv
         self._readback_pv = readback_pv
+        self._target_attr = target_attr
 
         super().__init__(prefix=prefix, limits=limits, name=name,
                          read_attrs=read_attrs,

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -101,8 +101,8 @@ class PVPositionerSoftDone(PVPositioner):
         self.setpoint.subscribe(self.cb_setpoint)
 
         if tolerance is None:
-            self.readback.wait_for_connection()
-            self.setpoint.wait_for_connection()
+            self.readback.wait_for_connection(timeout=5.0)
+            self.setpoint.wait_for_connection(timeout=5.0)
 
             rb = self.readback.precision
             sp = self.setpoint.precision


### PR DESCRIPTION
Changes all `PVPositionerSoftDone` to a modified version from @prjemian (https://github.com/BCDA-APS/bluesky_instrument_training/blob/main/instrument/devices/temperature_signal.py), which makes the code much simpler.

There are two main differences from Pete's version:
- Option to pass the `setpoint` and `readback` PVs in the `__init__`.
- Option to pass a `target_attr`. This is important for positioners that has ramping because if the `setpoint` is slowly changed by EPICS, then `readback.get() - setpoint.get()` might go to zero, and Bluesky things that the motion is done. The solution here is to create a `target` signal that will just hold to intended final position. Our lakeshore is a good example of this: 
https://github.com/APS-4ID-POLAR/ipython-polar/blob/6832cc2184dc3f03db01cbc0a4153aef90bf4ede/profile_bluesky/startup/instrument/devices/lakeshore340.py#L60

Close #96, closes #101.