### PR TITLE
2021-2 environment

### DIFF
--- a/profile_bluesky/startup/instrument/devices/huber.py
+++ b/profile_bluesky/startup/instrument/devices/huber.py
@@ -9,18 +9,17 @@ from ophyd import Component, FormattedComponent
 from ophyd import PseudoSingle
 from ophyd import EpicsSignal, EpicsSignalRO, EpicsMotor, Signal
 from bluesky.suspenders import SuspendBoolLow
-from apstools.diffractometer import DiffractometerMixin
 from ..framework import RE
 from ..framework import sd
 import gi
 gi.require_version('Hkl', '5.0')
 # MUST come before `import hkl`
-from hkl.diffract import E4CV
+from hkl.geometries import E4CV
 from ..session_logs import logger
 logger.info(__file__)
 
 
-class FourCircleDiffractometer(DiffractometerMixin, E4CV):
+class FourCircleDiffractometer(E4CV):
     """
     E4CV: huber diffractometer in 4-circle vertical geometry with energy.
 
@@ -70,46 +69,6 @@ class FourCircleDiffractometer(DiffractometerMixin, E4CV):
     # energy_EGU = Component(EpicsSignal, "optics:energy.EGU")
     energy_update_calc_flag = Component(Signal, value=1)
     energy_offset = Component(Signal, value=0)
-
-    @property
-    def _calc_energy_update_permitted(self):
-        """return boolean `True` if permitted."""
-        acceptable_values = (1, "Yes", "locked", "OK", True, "On")
-        return self.energy_update_calc_flag.get() in acceptable_values
-
-    def _energy_changed(self, value=None, **kwargs):
-        '''
-        Callback indicating that the energy signal was updated.
-        .. note::
-            The `energy` signal is subscribed to this method
-            in the :meth:`Diffractometer.__init__()` method.
-        '''
-        if not self.connected:
-            logger.warning(
-                "%s not fully connected, %s.calc.energy not updated",
-                self.name, self.name)
-            return
-
-        if self._calc_energy_update_permitted:
-            self._update_calc_energy(value)
-
-    def _update_calc_energy(self, value=None, **kwargs):
-        '''
-        writes self.calc.energy from value or self.energy.
-        '''
-        if not self.connected:
-            logger.warning(
-                "%s not fully connected, %s.calc.energy not updated",
-                self.name, self.name)
-            return
-
-        # use either supplied value or get from signal
-        value = value or self.energy.get()
-
-        # energy_offset has same units as energy
-        new_calc_energy = value + self.energy_offset.get()
-        self.calc.energy = new_calc_energy
-        self._update_position()
 
 
 fourc = FourCircleDiffractometer('4iddx:', name='fourc')

--- a/profile_bluesky/startup/instrument/devices/phaseplates.py
+++ b/profile_bluesky/startup/instrument/devices/phaseplates.py
@@ -16,8 +16,8 @@ from ..session_logs import logger
 
 # This is here because PRDevice.select_pr has a micron symbol that utf-8
 # cannot read. See: https://github.com/bluesky/ophyd/issues/930
-from epics import utils3
-utils3.EPICS_STR_ENCODING = "latin-1"
+from epics import utils
+utils.EPICS_STR_ENCODING = "latin-1"
 
 logger.info(__file__)
 


### PR DESCRIPTION
Updates for the 2021-2 conda environment.

- `pyepics` dropped python 2, so `utils3` -> `utils`
- `hklpy` incorporated some functions from `apstools`, and moved the `EC4V` location.