### PR TITLE
Beamline fixes

### DIFF
--- a/profile_bluesky/startup/instrument/devices/energy.py
+++ b/profile_bluesky/startup/instrument/devices/energy.py
@@ -33,11 +33,10 @@ class EnergySignal(Signal):
         status.set_finished()
 
         # Mono
-        if abs(self.get()-position) > mono.energy.tolerance.get():
-            mono_status = mono.energy.set(
-                position, wait=wait, timeout=timeout, moved_cb=moved_cb
-            )
-            status = AndStatus(status, mono_status)
+        mono_status = mono.energy.set(
+            position, wait=wait, timeout=timeout, moved_cb=moved_cb
+        )
+        status = AndStatus(status, mono_status)
 
         # Phase retarders
         for pr in [pr1, pr2, pr3]:

--- a/profile_bluesky/startup/instrument/devices/energy.py
+++ b/profile_bluesky/startup/instrument/devices/energy.py
@@ -62,10 +62,12 @@ class EnergySignal(Signal):
 
     def stop(self, *, success=False):
         """
-        Stops all energy related devices regardless if it's tracking or not.
+        Stops only energy devices that are tracking.
         """
-        for positioner in [mono, pr1, pr2, pr3, undulator.downstream]:
-            positioner.energy.stop(success=success)
+        mono.energy.stop(success=success)
+        for positioner in [pr1, pr2, pr3, undulator.downstream]:
+            if positioner.tracking.get():
+                positioner.energy.stop(success=success)
 
 
 energy = EnergySignal(name='energy', value=10, kind='hinted')

--- a/profile_bluesky/startup/instrument/devices/lakeshore336.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore336.py
@@ -120,11 +120,6 @@ class LS336_LoopControl(PVPositionerSoftDone):
     def pause(self):
         self.setpoint.put(self._position)
 
-    def move(self, position, **kwargs):
-        # Need to update the target.
-        self.target.put(position)
-        return super().move(position, **kwargs)
-
     @auto_heater.sub_value
     def _subscribe_auto_heater(self, value=None, **kwargs):
         if value:

--- a/profile_bluesky/startup/instrument/devices/lakeshore340.py
+++ b/profile_bluesky/startup/instrument/devices/lakeshore340.py
@@ -108,11 +108,6 @@ class LS340_LoopBase(PVPositionerSoftDone):
     def pause(self):
         self.setpoint.put(self._position, wait=True)
 
-    def move(self, position, **kwargs):
-        # Need to update the target.
-        self.target.put(position)
-        return super().move(position, **kwargs)
-
 
 class LS340_LoopControl(LS340_LoopBase):
     """ Control specific """

--- a/profile_bluesky/startup/instrument/devices/monochromator.py
+++ b/profile_bluesky/startup/instrument/devices/monochromator.py
@@ -31,8 +31,8 @@ class KohzuPositioner(PVPositionerSoftDone):
                                     kind="omitted")
     stop_y = FormattedComponent(EpicsSignal, "{_y_pv}.STOP",
                                 kind="omitted")
-    stop_z = FormattedComponent(EpicsSignal, "{_z_pv}.STOP",
-                                kind="omitted")
+    # stop_z = FormattedComponent(EpicsSignal, "{_z_pv}.STOP",
+    #                             kind="omitted")
 
     actuate = Component(EpicsSignal, "KohzuPutBO", kind="omitted")
     actuate_value = 1
@@ -48,7 +48,7 @@ class KohzuPositioner(PVPositionerSoftDone):
 
         self._theta_pv = get_motor_pv("Theta")
         self._y_pv = get_motor_pv("Y")
-        self._z_pv = get_motor_pv("Z")
+        # self._z_pv = get_motor_pv("Z")
 
         super().__init__(
             prefix, limits=limits, readback_pv=readback_pv,
@@ -58,7 +58,8 @@ class KohzuPositioner(PVPositionerSoftDone):
         )
 
     def stop(self, *, success=False):
-        for motor in ["theta", "y", "z"]:
+        # for motor in ["theta", "y", "z"]:
+        for motor in ["theta", "y"]:
             getattr(self, f"stop_{motor}").put(1, wait=False)
         super().stop(success=success)
 

--- a/profile_bluesky/startup/instrument/devices/phaseplates.py
+++ b/profile_bluesky/startup/instrument/devices/phaseplates.py
@@ -281,17 +281,18 @@ class PRSetup():
                             try:
                                 msg = "\tOffset (in degrees)"
                                 msg += f"({_current['offset']}): "
-                                offset = float(input(msg))
+                                offset = input(msg)
                                 if offset == '':
                                     offset = str(_current['offset'])
                                 _positioner.parent.offset_degrees.put(
-                                        float(offset))
+                                        float(offset)
+                                        )
                                 break
                             except ValueError:
                                 print('Must be a number.')
 
                         # if PZT is used, then get the center.
-                        if method == "pzt":
+                        if method.lower() == "pzt":
                             # Get offset signal
                             self.offset = _positioner.parent.offset_microns
                             # Get the PZT center.

--- a/profile_bluesky/startup/instrument/devices/slits.py
+++ b/profile_bluesky/startup/instrument/devices/slits.py
@@ -60,6 +60,8 @@ sd.baseline.append(wbslt)
 enslt = SlitDevice('4iddx:', 'enslt',
                    {'top': 'm1', 'bot': 'm2', 'out': 'm3', 'inb': 'm4'},
                    1)
+enslt.vcen.tolerance.put(0.003)
+enslt.vsize.tolerance.put(0.009)
 sd.baseline.append(enslt)
 
 # 8C incident slit

--- a/profile_bluesky/startup/instrument/devices/user_calc.py
+++ b/profile_bluesky/startup/instrument/devices/user_calc.py
@@ -79,10 +79,12 @@ class UserCalc(Device):
 
 
 absorption_calc = UserCalc('4id:userCalc9', name='absorption_calc')
-absorption_calc.scan.put(2)
+# TODO: this times out frequently during startup
+# absorption_calc.scan.put(2)
 
 normalize_calc = UserCalc('4id:userCalc10', name='normalize_calc')
-normalize_calc.scan.put(2)
+# TODO: this times out frequently during startups
+# normalize_calc.scan.put(2)
 
 sd.baseline.append(absorption_calc)
 sd.baseline.append(normalize_calc)

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -109,8 +109,8 @@ class PVPositionerSoftDone(PVPositioner):
             self.readback.wait_for_connection(timeout=5.0)
             self.setpoint.wait_for_connection(timeout=5.0)
 
-            rb = self.readback.precision
-            sp = self.setpoint.precision
+            rb = 10**(-1*self.readback.precision)
+            sp =  10**(-1*self.setpoint.precision)
 
             tolerance = rb if rb >= sp else sp
 

--- a/profile_bluesky/startup/instrument/devices/util_components.py
+++ b/profile_bluesky/startup/instrument/devices/util_components.py
@@ -112,9 +112,13 @@ class PVPositionerSoftDone(PVPositioner):
         '''Move and do not wait until motion is complete (asynchronous)'''
         self.log.debug('%s.setpoint = %s', self.name, position)
         self.setpoint.put(position, wait=False)
+        if self._target_attr != "setpoint":
+            getattr(self, self._target_attr).put(position, wait=False)
         if self.actuate is not None:
             self.log.debug('%s.actuate = %s', self.name, self.actuate_value)
             self.actuate.put(self.actuate_value, wait=False)
+        self.cb_setpoint()
+        self.cb_readback()
 
     @property
     def precision(self):

--- a/profile_bluesky/startup/instrument/plans/local_scans.py
+++ b/profile_bluesky/startup/instrument/plans/local_scans.py
@@ -91,27 +91,11 @@ def one_local_step(detectors, step, pos_cache, take_reading=trigger_and_read):
     yield from move_per_step(step, pos_cache)
 
     if flag.fixq:
-        # Pseudomotors `.get()` return a PseudoSingleTuple, but we want only
-        # the setpoint.
-#        hkl_pos = {
-#            fourc.h: fourc.h.get().readback,
-#            fourc.k: fourc.k.get().readback,
-#            fourc.l: fourc.l.get().readback,
-#        }
         devices_to_read += [fourc]
-        
-        # print(flag.hkl_pos)
-        
-        # yield from move_per_step(flag.hkl_pos, hkl_pos)
-        
         args = (fourc.h, flag.hkl_pos[fourc.h],
                 fourc.k, flag.hkl_pos[fourc.k],
                 fourc.l, flag.hkl_pos[fourc.l])
-        
-        # print(args)
-        
         yield from bps_mv(*args)
-
 
     if flag.dichro:
         yield from dichro_steps(devices_to_read, take_reading)

--- a/profile_bluesky/startup/instrument/plans/local_scans.py
+++ b/profile_bluesky/startup/instrument/plans/local_scans.py
@@ -30,6 +30,7 @@ logger.info(__file__)
 class LocalFlag:
     dichro = False
     fixq = False
+    hkl_pos = {}
 
 
 flag = LocalFlag()
@@ -92,13 +93,25 @@ def one_local_step(detectors, step, pos_cache, take_reading=trigger_and_read):
     if flag.fixq:
         # Pseudomotors `.get()` return a PseudoSingleTuple, but we want only
         # the setpoint.
-        hkl_pos = {
-            fourc.h: fourc.h.get().setpoint,
-            fourc.k: fourc.k.get().setpoint,
-            fourc.l: fourc.l.get().setpoint,
-        }
+#        hkl_pos = {
+#            fourc.h: fourc.h.get().readback,
+#            fourc.k: fourc.k.get().readback,
+#            fourc.l: fourc.l.get().readback,
+#        }
         devices_to_read += [fourc]
-        yield from move_per_step(hkl_pos, hkl_pos)
+        
+        # print(flag.hkl_pos)
+        
+        # yield from move_per_step(flag.hkl_pos, hkl_pos)
+        
+        args = (fourc.h, flag.hkl_pos[fourc.h],
+                fourc.k, flag.hkl_pos[fourc.k],
+                fourc.l, flag.hkl_pos[fourc.l])
+        
+        # print(args)
+        
+        yield from bps_mv(*args)
+
 
     if flag.dichro:
         yield from dichro_steps(devices_to_read, take_reading)
@@ -158,6 +171,12 @@ def lup(*args, time=None, detectors=None, lockin=False, dichro=False,
     flag.dichro = dichro
     flag.fixq = fixq
     per_step = one_local_step if fixq or dichro else None
+    if fixq:
+        flag.hkl_pos = {
+            fourc.h: fourc.h.get().setpoint,
+            fourc.k: fourc.k.get().setpoint,
+            fourc.l: fourc.l.get().setpoint,
+        }
 
     # This allows passing "time" without using the keyword.
     if len(args) % 3 == 2 and time is None:
@@ -245,6 +264,12 @@ def ascan(*args, time=None, detectors=None, lockin=False, dichro=False,
     flag.dichro = dichro
     flag.fixq = fixq
     per_step = one_local_step if fixq or dichro else None
+    if fixq:
+        flag.hkl_pos = {
+            fourc.h: fourc.h.get().setpoint,
+            fourc.k: fourc.k.get().setpoint,
+            fourc.l: fourc.l.get().setpoint,
+        }
 
     # This allows passing "time" without using the keyword.
     if len(args) % 3 == 2 and time is None:
@@ -327,6 +352,12 @@ def qxscan(edge_energy, time=None, detectors=None, lockin=False, dichro=False,
     flag.dichro = dichro
     flag.fixq = fixq
     per_step = one_local_step if fixq or dichro else None
+    if fixq:
+        flag.hkl_pos = {
+            fourc.h: fourc.h.get().setpoint,
+            fourc.k: fourc.k.get().setpoint,
+            fourc.l: fourc.l.get().setpoint,
+        }
 
     # Get energy argument and extras
     energy_list = yield from rd(qxscan_params.energy_list)


### PR DESCRIPTION
Corrects some of the issues found during tests at the beamline:
- `PVPositionerSoftDone` has a better handle of tolerances and the case where the positioner is sent to the current energy.
- Clear up some (but not all, see #125) startup timeouts.
- Fix `pr_setup` PZT bug.
- Fix "m19" complain. It tried to `energy` stop it but it's disabled (because it is `pr3.x`). Now `energy` only tries to stop devices that are tracking.

Fix #117, fix #118, fix #120, fix #122, fix #124.