### PR TITLE
Upgrades to qxscan_setup

### DIFF
--- a/profile_bluesky/startup/instrument/callbacks/dichro_plot.py
+++ b/profile_bluesky/startup/instrument/callbacks/dichro_plot.py
@@ -99,8 +99,8 @@ class AutoDichroPlot(AutoPlotter):
             return
 
         # Look for the scan_type='dichro' hint
-        scan_type = run.metadata["start"]["hints"].get('scan_type', None)
-        if scan_type != 'dichro':
+        scan_type = run.metadata["start"]["hints"].get('scan_type', "")
+        if 'dichro' not in scan_type:
             return
 
         # Detect x variable from hints in metadata.

--- a/profile_bluesky/startup/instrument/collection.py
+++ b/profile_bluesky/startup/instrument/collection.py
@@ -94,6 +94,7 @@ from IPython import get_ipython
 from .utils.local_magics import LocalMagics
 get_ipython().register_magics(LocalMagics)
 
+qxscan_params.load_from_scan(-1)
 
 # This is a workaround to ensure that we preserve the beamline energy and
 # the previously defined UB matrix.
@@ -104,5 +105,3 @@ def restore_orientation(orientation, diffractometer):
     diffractometer.UB.put(orientation["UB"])
     diffractometer.engine.mode = orientation["_mode"]
     diffractometer.energy.put(energy.get())
-
-qxscan_params.load_from_scan(-1)

--- a/profile_bluesky/startup/instrument/collection.py
+++ b/profile_bluesky/startup/instrument/collection.py
@@ -104,3 +104,5 @@ def restore_orientation(orientation, diffractometer):
     diffractometer.UB.put(orientation["UB"])
     diffractometer.engine.mode = orientation["_mode"]
     diffractometer.energy.put(energy.get())
+
+qxscan_params.load_from_scan(-1)

--- a/profile_bluesky/startup/instrument/devices/qxscan_setup.py
+++ b/profile_bluesky/startup/instrument/devices/qxscan_setup.py
@@ -88,7 +88,8 @@ class QxscanParams(Device):
         output += f"    energy start = {params['edge']['Estart']} eV\n"
         output += f"    energy step = {params['edge']['Estep']} eV\n"
         output += f"    energy end = {params['edge']['Eend']} eV\n"
-        output += f"    k end = {sqrt(constant*params['edge']['Eend'])} A^-1\n"
+        output += f"    k end = {sqrt(constant*params['edge']['Eend']) :0.3f}"
+        output += "A^-1\n"
         output += f"    time factor = {params['edge']['TimeFactor']}\n\n"
 
         output += "-- Post-edge --\n"

--- a/profile_bluesky/startup/instrument/devices/qxscan_setup.py
+++ b/profile_bluesky/startup/instrument/devices/qxscan_setup.py
@@ -23,20 +23,20 @@ constant = 2*electron_mass/hbar**2  # A^2/eV
 
 
 class EdgeDevice(Device):
-    Estart = Component(Signal, value=0)
-    Eend = Component(Signal, value=0)
-    Estep = Component(Signal, value=0)
+    Estart = Component(Signal, value=-10)
+    Eend = Component(Signal, value=10)
+    Estep = Component(Signal, value=0.5)
     TimeFactor = Component(Signal, value=1)
 
 
 class PreEdgeRegion(Device):
-    Estart = Component(Signal, value=0)
-    Estep = Component(Signal, value=0)
+    Estart = Component(Signal, value=-50)
+    Estep = Component(Signal, value=2)
     TimeFactor = Component(Signal, value=1)
 
 
 class PreEdgeDevice(Device):
-    num_regions = Component(Signal, value=0)
+    num_regions = Component(Signal, value=1)
     region1 = Component(PreEdgeRegion)
     region2 = Component(PreEdgeRegion)
     region3 = Component(PreEdgeRegion)
@@ -45,13 +45,13 @@ class PreEdgeDevice(Device):
 
 
 class PostEdgeRegion(Device):
-    Kend = Component(Signal, value=0)
-    Kstep = Component(Signal, value=0)
+    Kend = Component(Signal, value=4)
+    Kstep = Component(Signal, value=0.05)
     TimeFactor = Component(Signal, value=1)
 
 
 class PostEdgeDevice(Device):
-    num_regions = Component(Signal, value=0)
+    num_regions = Component(Signal, value=1)
     region1 = Component(PostEdgeRegion)
     region2 = Component(PostEdgeRegion)
     region3 = Component(PostEdgeRegion)

--- a/profile_bluesky/startup/instrument/devices/qxscan_setup.py
+++ b/profile_bluesky/startup/instrument/devices/qxscan_setup.py
@@ -421,7 +421,9 @@ class QxscanParams(Device):
             _update_value(item + ".num_regions")
             num_regions = getattr(self, item).num_regions.get()
             for i in range(1, num_regions + 1):
-                for component in getattr(self, item + f".region{i}"):
+                for component in getattr(
+                    self, item + f".region{i}"
+                ).component_names:
                     _update_value(item + f".region{i}.{component}")
 
 

--- a/profile_bluesky/startup/instrument/devices/qxscan_setup.py
+++ b/profile_bluesky/startup/instrument/devices/qxscan_setup.py
@@ -117,31 +117,60 @@ class QxscanParams(Device):
         print('Defining the energy range and steps for qxscan')
         print('All energies are relative to the absorption edge!')
 
+        def _update_value(text, _current):
+            _new = input(text.format(_current))
+            return float(_new) if _new != "" else _current
+
         while True:
-            value = int(input('\n Number of pre-edge regions: '))
+            value = int(input(
+                '\n Number of pre-edge regions ('
+                f'{self.pre_edge.num_regions.get()}): '
+                ))
             if 1 <= value <= 5:
                 self.pre_edge.num_regions.put(value)
                 break
+            elif value == "":
+                break
             else:
-                print('WARNING: number of pre-edge regions need to be >=1 and \
-                    <= 5!')
+                print(
+                    'WARNING: number of pre-edge regions need to be >=1 and'
+                    '<= 5!'
+                )
 
         for i in range(self.pre_edge.num_regions.get()):
             print('\n Defining pre-edge #{}'.format(i+1))
-            relative_energy = float(input('Start energy (in eV): '))
-            energy_increment = float(input('Energy increment (in eV): '))
-            time_factor = float(input('Counting time factor: '))
 
-            region = getattr(self.pre_edge, 'region{}'.format(i+1))
+            region = getattr(self.pre_edge, f"region{i+1}")
+
+            relative_energy = _update_value(
+                "Start energy (in eV) ({}): ", region.Estart.get()
+            )
+
+            energy_increment = _update_value(
+                'Energy increment (in eV) ({}): ', region.Estep.get()
+            )
+
+            time_factor = _update_value(
+                'Counting time factor ({}): ', region.TimeFactor.get()
+            )
+
             region.Estart.put(relative_energy)
             region.Estep.put(energy_increment)
             region.TimeFactor.put(time_factor)
 
         print('\n Defining edge region')
-        relative_energy_start = float(input('Start energy (in eV): '))
-        relative_energy_end = float(input('Final energy (in eV): '))
-        energy_increment = float(input('Energy increment (in eV): '))
-        time_factor = float(input('Counting time factor: '))
+        relative_energy_start = _update_value(
+            'Start energy (in eV) ({}): ', self.edge.Estart.get()
+        )
+        relative_energy_end = _update_value(
+            'Final energy (in eV) ({}): ', self.edge.Eend.get()
+        )
+        energy_increment = _update_value(
+            'Energy increment (in eV) ({}): ', self.edge.Estep.get()
+        )
+        time_factor = _update_value(
+            'Counting time factor ({}): ', self.edge.TimeFactor.get()
+        )
 
         self.edge.Estart.put(relative_energy_start)
         self.edge.Eend.put(relative_energy_end)
@@ -152,9 +181,14 @@ class QxscanParams(Device):
         print('The edge region ends at k = {:0.3f} angstroms^-1'.format(kend))
 
         while True:
-            value = int(input('\n Number of post-edge regions: '))
+            value = int(input(
+                '\n Number of post-edge regions ('
+                f'{self.post_edge.num_regions.get()}): '
+                ))
             if 1 <= value <= 5:
                 self.post_edge.num_regions.put(value)
+                break
+            elif value == "":
                 break
             else:
                 print('WARNING: number of post-edge regions need to be >= 1 \
@@ -162,11 +196,18 @@ class QxscanParams(Device):
 
         for i in range(self.post_edge.num_regions.get()):
             print('\n Defining post-edge #{}'.format(i+1))
-            relative_k = float(input('k end (in angstroms^-1): '))
-            k_increment = float(input('k increment (in angstroms^-1): '))
-            time_factor = float(input('Counting time factor: '))
-
             region = getattr(self.post_edge, 'region{}'.format(i+1))
+
+            relative_k = _update_value(
+                'k end (in angstroms^-1) ({}): ', self.post_edge.Kend.get()
+            )
+            k_increment = _update_value(
+                'k increment (in angstroms^-1) ({}): ', self.edge.Kstep.get()
+            )
+            time_factor = _update_value(
+                'Counting time factor ({}): ', self.edge.TimeFactor.get()
+            )
+
             region.Kend.put(relative_k)
             region.Kstep.put(k_increment)
             region.TimeFactor.put(time_factor)

--- a/profile_bluesky/startup/instrument/plans/local_scans.py
+++ b/profile_bluesky/startup/instrument/plans/local_scans.py
@@ -312,8 +312,11 @@ def ascan(*args, time=None, detectors=None, lockin=False, dichro=False,
     for item in detectors:
         _md['hints']['detectors'].extend(item.hints['fields'])
 
+    _md["hints"]["scan_type"] = "ascan"
     if dichro:
-        _md['hints']['scan_type'] = 'dichro'
+        _md['hints']['scan_type'] += " dichro"
+    if lockin:
+        _md['hints']['scan_type'] += " lockin"
 
     _md.update(md or {})
 
@@ -498,8 +501,11 @@ def grid_scan(*args, time=None, detectors=None, snake_axes=None, lockin=False,
     for item in detectors:
         _md['hints']['detectors'].extend(item.hints['fields'])
 
+    _md["hints"]["scan_type"] = "gridscan"
     if dichro:
-        _md['hints']['scan_type'] = 'dichro'
+        _md['hints']['scan_type'] += " dichro"
+    if lockin:
+        _md['hints']['scan_type'] += " lockin"
 
     _md.update(md or {})
 
@@ -674,8 +680,11 @@ def qxscan(edge_energy, time=None, detectors=None, lockin=False, dichro=False,
     for item in detectors:
         _md['hints']['detectors'].extend(item.hints['fields'])
 
+    _md["hints"]["scan_type"] = "qxscan"
     if dichro:
-        _md['hints']['scan_type'] = 'dichro'
+        _md['hints']['scan_type'] += " dichro"
+    if lockin:
+        _md['hints']['scan_type'] += " lockin"
 
     _md.update(md or {})
 


### PR DESCRIPTION
Two main updates:

+ Adds an option to recover the parameters from a previous scan by reading the info from the baseline stream (closes #151). This runs at the startup to load the parameters from last scan, so I think there is no need for PVs (closes #123).
+ Updates the parameter entering script to use the last input as default values.

Additionally:

+ I think this is a better solution than adding to the metadata (closes #81).
+ Tweak the metadata["start"]["hints"] to add information about whether it is a qxscan.
