### PR TITLE
Temporary fix for the PVPositionerSoftDone

### DIFF
--- a/profile_bluesky/startup/instrument/devices/_pvpositionersoftdone.py
+++ b/profile_bluesky/startup/instrument/devices/_pvpositionersoftdone.py
@@ -1,0 +1,7 @@
+from apstools.devices import PVPositionerSoftDoneWithStop as PVPos
+
+
+class PVPositionerSoftDoneWithStop(PVPos):
+    def _setup_move(self, position):
+        self.cb_setpoint()
+        super()._setup_move(position)

--- a/profile_bluesky/startup/instrument/devices/ge_controller.py
+++ b/profile_bluesky/startup/instrument/devices/ge_controller.py
@@ -5,7 +5,8 @@ GE pressure controllers
 __all__ = ['ge_apply', 'ge_release']
 
 from ophyd import Component, EpicsSignalRO, EpicsSignalWithRBV
-from apstools.devices import PVPositionerSoftDoneWithStop
+# from apstools.devices import PVPositionerSoftDoneWithStop
+from ._pvpositionersoftdone import PVPositionerSoftDoneWithStop
 from ..framework import sd
 from ..session_logs import logger
 logger.info(__file__)

--- a/profile_bluesky/startup/instrument/devices/kepko.py
+++ b/profile_bluesky/startup/instrument/devices/kepko.py
@@ -7,7 +7,8 @@ __all__ = ['kepko']
 from ophyd import Component, FormattedComponent, Device, Kind
 from ophyd import EpicsSignal, EpicsSignalRO
 from ..framework import sd
-from apstools.devices import PVPositionerSoftDoneWithStop
+# from apstools.devices import PVPositionerSoftDoneWithStop
+from ._pvpositionersoftdone import PVPositionerSoftDoneWithStop
 
 from ..session_logs import logger
 logger.info(__file__)

--- a/profile_bluesky/startup/instrument/devices/phaseplates.py
+++ b/profile_bluesky/startup/instrument/devices/phaseplates.py
@@ -12,7 +12,9 @@ from ophyd import EpicsSignal, EpicsSignalRO, Signal, DerivedSignal
 from ophyd.pseudopos import pseudo_position_argument, real_position_argument
 from scipy.constants import speed_of_light, Planck
 from numpy import arcsin, pi, sin
-from apstools.devices import TrackingSignal, PVPositionerSoftDoneWithStop
+from apstools.devices import TrackingSignal
+# from apstools.devices import PVPositionerSoftDoneWithStop
+from ._pvpositionersoftdone import PVPositionerSoftDoneWithStop
 from ..session_logs import logger
 
 # This is here because PRDevice.select_pr has a micron symbol that utf-8

--- a/profile_bluesky/startup/instrument/devices/ruby_motors.py
+++ b/profile_bluesky/startup/instrument/devices/ruby_motors.py
@@ -8,7 +8,8 @@ from ophyd import (
     Component, Device, EpicsMotor, EpicsSignal, FormattedComponent
 )
 from ..framework import sd
-from apstools.devices import PVPositionerSoftDoneWithStop
+# from apstools.devices import PVPositionerSoftDoneWithStop
+from ._pvpositionersoftdone import PVPositionerSoftDoneWithStop
 from ..session_logs import logger
 logger.info(__file__)
 

--- a/profile_bluesky/startup/instrument/devices/slits.py
+++ b/profile_bluesky/startup/instrument/devices/slits.py
@@ -4,7 +4,8 @@ Slits
 __all__ = ['wbslt', 'enslt', 'inslt', 'grdslt', 'detslt', 'magslt']
 
 from ophyd import Device, FormattedComponent, EpicsMotor
-from apstools.devices import PVPositionerSoftDoneWithStop
+# from apstools.devices import PVPositionerSoftDoneWithStop
+from ._pvpositionersoftdone import PVPositionerSoftDoneWithStop
 from ..framework import sd
 from ..session_logs import logger
 logger.info(__file__)


### PR DESCRIPTION
Devices that use PVPositionerSoftDone are getting stuck if sent to the same position as the current one. This is meant to be temporary until this gets resolved in `apstools` (https://github.com/BCDA-APS/apstools/issues/725).